### PR TITLE
Fixed POST/PUT object leftover attribute issue

### DIFF
--- a/pkg/client/access_control_records_object_set.go
+++ b/pkg/client/access_control_records_object_set.go
@@ -22,14 +22,9 @@ type AccessControlRecordObjectSet struct {
 
 // CreateObject creates a new AccessControlRecord object
 func (objectSet *AccessControlRecordObjectSet) CreateObject(payload *nimbleos.AccessControlRecord) (*nimbleos.AccessControlRecord, error) {
-	resp, err := objectSet.Client.Post(accessControlRecordPath, payload)
+	resp, err := objectSet.Client.Post(accessControlRecordPath, payload, &nimbleos.AccessControlRecord{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.AccessControlRecord), err

--- a/pkg/client/active_directory_memberships_object_set.go
+++ b/pkg/client/active_directory_memberships_object_set.go
@@ -22,14 +22,9 @@ type ActiveDirectoryMembershipObjectSet struct {
 
 // CreateObject creates a new ActiveDirectoryMembership object
 func (objectSet *ActiveDirectoryMembershipObjectSet) CreateObject(payload *nimbleos.ActiveDirectoryMembership) (*nimbleos.ActiveDirectoryMembership, error) {
-	resp, err := objectSet.Client.Post(activeDirectoryMembershipPath, payload)
+	resp, err := objectSet.Client.Post(activeDirectoryMembershipPath, payload, &nimbleos.ActiveDirectoryMembership{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ActiveDirectoryMembership), err
@@ -37,15 +32,11 @@ func (objectSet *ActiveDirectoryMembershipObjectSet) CreateObject(payload *nimbl
 
 // UpdateObject Modify existing ActiveDirectoryMembership object
 func (objectSet *ActiveDirectoryMembershipObjectSet) UpdateObject(id string, payload *nimbleos.ActiveDirectoryMembership) (*nimbleos.ActiveDirectoryMembership, error) {
-	resp, err := objectSet.Client.Put(activeDirectoryMembershipPath, id, payload)
+	resp, err := objectSet.Client.Put(activeDirectoryMembershipPath, id, payload, &nimbleos.ActiveDirectoryMembership{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ActiveDirectoryMembership), err
 }
 

--- a/pkg/client/alarms_object_set.go
+++ b/pkg/client/alarms_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *AlarmObjectSet) CreateObject(payload *nimbleos.Alarm) (*nimbleo
 
 // UpdateObject Modify existing Alarm object
 func (objectSet *AlarmObjectSet) UpdateObject(id string, payload *nimbleos.Alarm) (*nimbleos.Alarm, error) {
-	resp, err := objectSet.Client.Put(alarmPath, id, payload)
+	resp, err := objectSet.Client.Put(alarmPath, id, payload, &nimbleos.Alarm{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Alarm), err
 }
 

--- a/pkg/client/application_servers_object_set.go
+++ b/pkg/client/application_servers_object_set.go
@@ -21,14 +21,9 @@ type ApplicationServerObjectSet struct {
 
 // CreateObject creates a new ApplicationServer object
 func (objectSet *ApplicationServerObjectSet) CreateObject(payload *nimbleos.ApplicationServer) (*nimbleos.ApplicationServer, error) {
-	resp, err := objectSet.Client.Post(applicationServerPath, payload)
+	resp, err := objectSet.Client.Post(applicationServerPath, payload, &nimbleos.ApplicationServer{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ApplicationServer), err
@@ -36,15 +31,11 @@ func (objectSet *ApplicationServerObjectSet) CreateObject(payload *nimbleos.Appl
 
 // UpdateObject Modify existing ApplicationServer object
 func (objectSet *ApplicationServerObjectSet) UpdateObject(id string, payload *nimbleos.ApplicationServer) (*nimbleos.ApplicationServer, error) {
-	resp, err := objectSet.Client.Put(applicationServerPath, id, payload)
+	resp, err := objectSet.Client.Put(applicationServerPath, id, payload, &nimbleos.ApplicationServer{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ApplicationServer), err
 }
 

--- a/pkg/client/arrays_object_set.go
+++ b/pkg/client/arrays_object_set.go
@@ -21,14 +21,9 @@ type ArrayObjectSet struct {
 
 // CreateObject creates a new Array object
 func (objectSet *ArrayObjectSet) CreateObject(payload *nimbleos.Array) (*nimbleos.Array, error) {
-	resp, err := objectSet.Client.Post(arrayPath, payload)
+	resp, err := objectSet.Client.Post(arrayPath, payload, &nimbleos.Array{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Array), err
@@ -36,15 +31,11 @@ func (objectSet *ArrayObjectSet) CreateObject(payload *nimbleos.Array) (*nimbleo
 
 // UpdateObject Modify existing Array object
 func (objectSet *ArrayObjectSet) UpdateObject(id string, payload *nimbleos.Array) (*nimbleos.Array, error) {
-	resp, err := objectSet.Client.Put(arrayPath, id, payload)
+	resp, err := objectSet.Client.Put(arrayPath, id, payload, &nimbleos.Array{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Array), err
 }
 

--- a/pkg/client/chap_users_object_set.go
+++ b/pkg/client/chap_users_object_set.go
@@ -23,14 +23,9 @@ type ChapUserObjectSet struct {
 
 // CreateObject creates a new ChapUser object
 func (objectSet *ChapUserObjectSet) CreateObject(payload *nimbleos.ChapUser) (*nimbleos.ChapUser, error) {
-	resp, err := objectSet.Client.Post(chapUserPath, payload)
+	resp, err := objectSet.Client.Post(chapUserPath, payload, &nimbleos.ChapUser{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ChapUser), err
@@ -38,15 +33,11 @@ func (objectSet *ChapUserObjectSet) CreateObject(payload *nimbleos.ChapUser) (*n
 
 // UpdateObject Modify existing ChapUser object
 func (objectSet *ChapUserObjectSet) UpdateObject(id string, payload *nimbleos.ChapUser) (*nimbleos.ChapUser, error) {
-	resp, err := objectSet.Client.Put(chapUserPath, id, payload)
+	resp, err := objectSet.Client.Put(chapUserPath, id, payload, &nimbleos.ChapUser{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ChapUser), err
 }
 

--- a/pkg/client/disks_object_set.go
+++ b/pkg/client/disks_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *DiskObjectSet) CreateObject(payload *nimbleos.Disk) (*nimbleos.
 
 // UpdateObject Modify existing Disk object
 func (objectSet *DiskObjectSet) UpdateObject(id string, payload *nimbleos.Disk) (*nimbleos.Disk, error) {
-	resp, err := objectSet.Client.Put(diskPath, id, payload)
+	resp, err := objectSet.Client.Put(diskPath, id, payload, &nimbleos.Disk{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Disk), err
 }
 

--- a/pkg/client/fibre_channel_interfaces_object_set.go
+++ b/pkg/client/fibre_channel_interfaces_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *FibreChannelInterfaceObjectSet) CreateObject(payload *nimbleos.
 
 // UpdateObject Modify existing FibreChannelInterface object
 func (objectSet *FibreChannelInterfaceObjectSet) UpdateObject(id string, payload *nimbleos.FibreChannelInterface) (*nimbleos.FibreChannelInterface, error) {
-	resp, err := objectSet.Client.Put(fibreChannelInterfacePath, id, payload)
+	resp, err := objectSet.Client.Put(fibreChannelInterfacePath, id, payload, &nimbleos.FibreChannelInterface{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.FibreChannelInterface), err
 }
 

--- a/pkg/client/folders_object_set.go
+++ b/pkg/client/folders_object_set.go
@@ -21,14 +21,9 @@ type FolderObjectSet struct {
 
 // CreateObject creates a new Folder object
 func (objectSet *FolderObjectSet) CreateObject(payload *nimbleos.Folder) (*nimbleos.Folder, error) {
-	resp, err := objectSet.Client.Post(folderPath, payload)
+	resp, err := objectSet.Client.Post(folderPath, payload, &nimbleos.Folder{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Folder), err
@@ -36,15 +31,11 @@ func (objectSet *FolderObjectSet) CreateObject(payload *nimbleos.Folder) (*nimbl
 
 // UpdateObject Modify existing Folder object
 func (objectSet *FolderObjectSet) UpdateObject(id string, payload *nimbleos.Folder) (*nimbleos.Folder, error) {
-	resp, err := objectSet.Client.Put(folderPath, id, payload)
+	resp, err := objectSet.Client.Put(folderPath, id, payload, &nimbleos.Folder{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Folder), err
 }
 

--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -89,7 +89,7 @@ func (client *GroupMgmtClient) login(username, password string) (string, error) 
 }
 
 // Post :
-func (client *GroupMgmtClient) Post(path string, payload interface{}) (interface{}, error) {
+func (client *GroupMgmtClient) Post(path string, payload interface{}, respHolder interface{}) (interface{}, error) {
 	// build the url
 	url := fmt.Sprintf("%s/%s", client.URL, path)
 
@@ -111,11 +111,11 @@ func (client *GroupMgmtClient) Post(path string, payload interface{}) (interface
 		}
 		return nil, fmt.Errorf("http response error: status (%d), messages: %v", response.StatusCode(), errResp)
 	}
-	return unwrap(response.Body(), payload)
+	return unwrap(response.Body(), respHolder)
 }
 
 // Put :
-func (client *GroupMgmtClient) Put(path, id string, payload interface{}) (interface{}, error) {
+func (client *GroupMgmtClient) Put(path, id string, payload interface{}, respHolder interface{}) (interface{}, error) {
 	// build the url
 	url := fmt.Sprintf("%s/%s/%s", client.URL, path, id)
 
@@ -137,7 +137,7 @@ func (client *GroupMgmtClient) Put(path, id string, payload interface{}) (interf
 		}
 		return nil, fmt.Errorf("http response error: status (%d), messages: %v", response.StatusCode(), errResp)
 	}
-	return unwrap(response.Body(), payload)
+	return unwrap(response.Body(), respHolder)
 }
 
 // Get : Only used to get a single object with the given ID

--- a/pkg/client/groups_object_set.go
+++ b/pkg/client/groups_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *GroupObjectSet) CreateObject(payload *nimbleos.Group) (*nimbleo
 
 // UpdateObject Modify existing Group object
 func (objectSet *GroupObjectSet) UpdateObject(id string, payload *nimbleos.Group) (*nimbleos.Group, error) {
-	resp, err := objectSet.Client.Put(groupPath, id, payload)
+	resp, err := objectSet.Client.Put(groupPath, id, payload, &nimbleos.Group{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Group), err
 }
 

--- a/pkg/client/initiator_groups_object_set.go
+++ b/pkg/client/initiator_groups_object_set.go
@@ -22,14 +22,9 @@ type InitiatorGroupObjectSet struct {
 
 // CreateObject creates a new InitiatorGroup object
 func (objectSet *InitiatorGroupObjectSet) CreateObject(payload *nimbleos.InitiatorGroup) (*nimbleos.InitiatorGroup, error) {
-	resp, err := objectSet.Client.Post(initiatorGroupPath, payload)
+	resp, err := objectSet.Client.Post(initiatorGroupPath, payload, &nimbleos.InitiatorGroup{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.InitiatorGroup), err
@@ -37,15 +32,11 @@ func (objectSet *InitiatorGroupObjectSet) CreateObject(payload *nimbleos.Initiat
 
 // UpdateObject Modify existing InitiatorGroup object
 func (objectSet *InitiatorGroupObjectSet) UpdateObject(id string, payload *nimbleos.InitiatorGroup) (*nimbleos.InitiatorGroup, error) {
-	resp, err := objectSet.Client.Put(initiatorGroupPath, id, payload)
+	resp, err := objectSet.Client.Put(initiatorGroupPath, id, payload, &nimbleos.InitiatorGroup{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.InitiatorGroup), err
 }
 

--- a/pkg/client/initiators_object_set.go
+++ b/pkg/client/initiators_object_set.go
@@ -22,14 +22,9 @@ type InitiatorObjectSet struct {
 
 // CreateObject creates a new Initiator object
 func (objectSet *InitiatorObjectSet) CreateObject(payload *nimbleos.Initiator) (*nimbleos.Initiator, error) {
-	resp, err := objectSet.Client.Post(initiatorPath, payload)
+	resp, err := objectSet.Client.Post(initiatorPath, payload, &nimbleos.Initiator{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Initiator), err

--- a/pkg/client/key_managers_object_set.go
+++ b/pkg/client/key_managers_object_set.go
@@ -22,14 +22,9 @@ type KeyManagerObjectSet struct {
 
 // CreateObject creates a new KeyManager object
 func (objectSet *KeyManagerObjectSet) CreateObject(payload *nimbleos.KeyManager) (*nimbleos.KeyManager, error) {
-	resp, err := objectSet.Client.Post(keyManagerPath, payload)
+	resp, err := objectSet.Client.Post(keyManagerPath, payload, &nimbleos.KeyManager{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.KeyManager), err
@@ -37,15 +32,11 @@ func (objectSet *KeyManagerObjectSet) CreateObject(payload *nimbleos.KeyManager)
 
 // UpdateObject Modify existing KeyManager object
 func (objectSet *KeyManagerObjectSet) UpdateObject(id string, payload *nimbleos.KeyManager) (*nimbleos.KeyManager, error) {
-	resp, err := objectSet.Client.Put(keyManagerPath, id, payload)
+	resp, err := objectSet.Client.Put(keyManagerPath, id, payload, &nimbleos.KeyManager{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.KeyManager), err
 }
 

--- a/pkg/client/master_key_object_set.go
+++ b/pkg/client/master_key_object_set.go
@@ -23,14 +23,9 @@ type MasterKeyObjectSet struct {
 
 // CreateObject creates a new MasterKey object
 func (objectSet *MasterKeyObjectSet) CreateObject(payload *nimbleos.MasterKey) (*nimbleos.MasterKey, error) {
-	resp, err := objectSet.Client.Post(masterKeyPath, payload)
+	resp, err := objectSet.Client.Post(masterKeyPath, payload, &nimbleos.MasterKey{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.MasterKey), err
@@ -38,15 +33,11 @@ func (objectSet *MasterKeyObjectSet) CreateObject(payload *nimbleos.MasterKey) (
 
 // UpdateObject Modify existing MasterKey object
 func (objectSet *MasterKeyObjectSet) UpdateObject(id string, payload *nimbleos.MasterKey) (*nimbleos.MasterKey, error) {
-	resp, err := objectSet.Client.Put(masterKeyPath, id, payload)
+	resp, err := objectSet.Client.Put(masterKeyPath, id, payload, &nimbleos.MasterKey{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.MasterKey), err
 }
 

--- a/pkg/client/network_configs_object_set.go
+++ b/pkg/client/network_configs_object_set.go
@@ -21,14 +21,9 @@ type NetworkConfigObjectSet struct {
 
 // CreateObject creates a new NetworkConfig object
 func (objectSet *NetworkConfigObjectSet) CreateObject(payload *nimbleos.NetworkConfig) (*nimbleos.NetworkConfig, error) {
-	resp, err := objectSet.Client.Post(networkConfigPath, payload)
+	resp, err := objectSet.Client.Post(networkConfigPath, payload, &nimbleos.NetworkConfig{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.NetworkConfig), err
@@ -36,15 +31,11 @@ func (objectSet *NetworkConfigObjectSet) CreateObject(payload *nimbleos.NetworkC
 
 // UpdateObject Modify existing NetworkConfig object
 func (objectSet *NetworkConfigObjectSet) UpdateObject(id string, payload *nimbleos.NetworkConfig) (*nimbleos.NetworkConfig, error) {
-	resp, err := objectSet.Client.Put(networkConfigPath, id, payload)
+	resp, err := objectSet.Client.Put(networkConfigPath, id, payload, &nimbleos.NetworkConfig{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.NetworkConfig), err
 }
 

--- a/pkg/client/performance_policies_object_set.go
+++ b/pkg/client/performance_policies_object_set.go
@@ -23,14 +23,9 @@ type PerformancePolicyObjectSet struct {
 
 // CreateObject creates a new PerformancePolicy object
 func (objectSet *PerformancePolicyObjectSet) CreateObject(payload *nimbleos.PerformancePolicy) (*nimbleos.PerformancePolicy, error) {
-	resp, err := objectSet.Client.Post(performancePolicyPath, payload)
+	resp, err := objectSet.Client.Post(performancePolicyPath, payload, &nimbleos.PerformancePolicy{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.PerformancePolicy), err
@@ -38,15 +33,11 @@ func (objectSet *PerformancePolicyObjectSet) CreateObject(payload *nimbleos.Perf
 
 // UpdateObject Modify existing PerformancePolicy object
 func (objectSet *PerformancePolicyObjectSet) UpdateObject(id string, payload *nimbleos.PerformancePolicy) (*nimbleos.PerformancePolicy, error) {
-	resp, err := objectSet.Client.Put(performancePolicyPath, id, payload)
+	resp, err := objectSet.Client.Put(performancePolicyPath, id, payload, &nimbleos.PerformancePolicy{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.PerformancePolicy), err
 }
 

--- a/pkg/client/pools_object_set.go
+++ b/pkg/client/pools_object_set.go
@@ -21,14 +21,9 @@ type PoolObjectSet struct {
 
 // CreateObject creates a new Pool object
 func (objectSet *PoolObjectSet) CreateObject(payload *nimbleos.Pool) (*nimbleos.Pool, error) {
-	resp, err := objectSet.Client.Post(poolPath, payload)
+	resp, err := objectSet.Client.Post(poolPath, payload, &nimbleos.Pool{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Pool), err
@@ -36,15 +31,11 @@ func (objectSet *PoolObjectSet) CreateObject(payload *nimbleos.Pool) (*nimbleos.
 
 // UpdateObject Modify existing Pool object
 func (objectSet *PoolObjectSet) UpdateObject(id string, payload *nimbleos.Pool) (*nimbleos.Pool, error) {
-	resp, err := objectSet.Client.Put(poolPath, id, payload)
+	resp, err := objectSet.Client.Put(poolPath, id, payload, &nimbleos.Pool{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Pool), err
 }
 

--- a/pkg/client/protection_schedules_object_set.go
+++ b/pkg/client/protection_schedules_object_set.go
@@ -21,14 +21,9 @@ type ProtectionScheduleObjectSet struct {
 
 // CreateObject creates a new ProtectionSchedule object
 func (objectSet *ProtectionScheduleObjectSet) CreateObject(payload *nimbleos.ProtectionSchedule) (*nimbleos.ProtectionSchedule, error) {
-	resp, err := objectSet.Client.Post(protectionSchedulePath, payload)
+	resp, err := objectSet.Client.Post(protectionSchedulePath, payload, &nimbleos.ProtectionSchedule{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ProtectionSchedule), err
@@ -36,15 +31,11 @@ func (objectSet *ProtectionScheduleObjectSet) CreateObject(payload *nimbleos.Pro
 
 // UpdateObject Modify existing ProtectionSchedule object
 func (objectSet *ProtectionScheduleObjectSet) UpdateObject(id string, payload *nimbleos.ProtectionSchedule) (*nimbleos.ProtectionSchedule, error) {
-	resp, err := objectSet.Client.Put(protectionSchedulePath, id, payload)
+	resp, err := objectSet.Client.Put(protectionSchedulePath, id, payload, &nimbleos.ProtectionSchedule{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ProtectionSchedule), err
 }
 

--- a/pkg/client/protection_templates_object_set.go
+++ b/pkg/client/protection_templates_object_set.go
@@ -24,14 +24,9 @@ type ProtectionTemplateObjectSet struct {
 
 // CreateObject creates a new ProtectionTemplate object
 func (objectSet *ProtectionTemplateObjectSet) CreateObject(payload *nimbleos.ProtectionTemplate) (*nimbleos.ProtectionTemplate, error) {
-	resp, err := objectSet.Client.Post(protectionTemplatePath, payload)
+	resp, err := objectSet.Client.Post(protectionTemplatePath, payload, &nimbleos.ProtectionTemplate{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ProtectionTemplate), err
@@ -39,15 +34,11 @@ func (objectSet *ProtectionTemplateObjectSet) CreateObject(payload *nimbleos.Pro
 
 // UpdateObject Modify existing ProtectionTemplate object
 func (objectSet *ProtectionTemplateObjectSet) UpdateObject(id string, payload *nimbleos.ProtectionTemplate) (*nimbleos.ProtectionTemplate, error) {
-	resp, err := objectSet.Client.Put(protectionTemplatePath, id, payload)
+	resp, err := objectSet.Client.Put(protectionTemplatePath, id, payload, &nimbleos.ProtectionTemplate{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ProtectionTemplate), err
 }
 

--- a/pkg/client/replication_partners_object_set.go
+++ b/pkg/client/replication_partners_object_set.go
@@ -23,14 +23,9 @@ type ReplicationPartnerObjectSet struct {
 
 // CreateObject creates a new ReplicationPartner object
 func (objectSet *ReplicationPartnerObjectSet) CreateObject(payload *nimbleos.ReplicationPartner) (*nimbleos.ReplicationPartner, error) {
-	resp, err := objectSet.Client.Post(replicationPartnerPath, payload)
+	resp, err := objectSet.Client.Post(replicationPartnerPath, payload, &nimbleos.ReplicationPartner{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.ReplicationPartner), err
@@ -38,15 +33,11 @@ func (objectSet *ReplicationPartnerObjectSet) CreateObject(payload *nimbleos.Rep
 
 // UpdateObject Modify existing ReplicationPartner object
 func (objectSet *ReplicationPartnerObjectSet) UpdateObject(id string, payload *nimbleos.ReplicationPartner) (*nimbleos.ReplicationPartner, error) {
-	resp, err := objectSet.Client.Put(replicationPartnerPath, id, payload)
+	resp, err := objectSet.Client.Put(replicationPartnerPath, id, payload, &nimbleos.ReplicationPartner{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.ReplicationPartner), err
 }
 

--- a/pkg/client/shelves_object_set.go
+++ b/pkg/client/shelves_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *ShelfObjectSet) CreateObject(payload *nimbleos.Shelf) (*nimbleo
 
 // UpdateObject Modify existing Shelf object
 func (objectSet *ShelfObjectSet) UpdateObject(id string, payload *nimbleos.Shelf) (*nimbleos.Shelf, error) {
-	resp, err := objectSet.Client.Put(shelfPath, id, payload)
+	resp, err := objectSet.Client.Put(shelfPath, id, payload, &nimbleos.Shelf{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Shelf), err
 }
 

--- a/pkg/client/snapshot_collections_object_set.go
+++ b/pkg/client/snapshot_collections_object_set.go
@@ -22,14 +22,9 @@ type SnapshotCollectionObjectSet struct {
 
 // CreateObject creates a new SnapshotCollection object
 func (objectSet *SnapshotCollectionObjectSet) CreateObject(payload *nimbleos.SnapshotCollection) (*nimbleos.SnapshotCollection, error) {
-	resp, err := objectSet.Client.Post(snapshotCollectionPath, payload)
+	resp, err := objectSet.Client.Post(snapshotCollectionPath, payload, &nimbleos.SnapshotCollection{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.SnapshotCollection), err
@@ -37,15 +32,11 @@ func (objectSet *SnapshotCollectionObjectSet) CreateObject(payload *nimbleos.Sna
 
 // UpdateObject Modify existing SnapshotCollection object
 func (objectSet *SnapshotCollectionObjectSet) UpdateObject(id string, payload *nimbleos.SnapshotCollection) (*nimbleos.SnapshotCollection, error) {
-	resp, err := objectSet.Client.Put(snapshotCollectionPath, id, payload)
+	resp, err := objectSet.Client.Put(snapshotCollectionPath, id, payload, &nimbleos.SnapshotCollection{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.SnapshotCollection), err
 }
 

--- a/pkg/client/snapshots_object_set.go
+++ b/pkg/client/snapshots_object_set.go
@@ -23,14 +23,9 @@ type SnapshotObjectSet struct {
 
 // CreateObject creates a new Snapshot object
 func (objectSet *SnapshotObjectSet) CreateObject(payload *nimbleos.Snapshot) (*nimbleos.Snapshot, error) {
-	resp, err := objectSet.Client.Post(snapshotPath, payload)
+	resp, err := objectSet.Client.Post(snapshotPath, payload, &nimbleos.Snapshot{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Snapshot), err
@@ -38,15 +33,11 @@ func (objectSet *SnapshotObjectSet) CreateObject(payload *nimbleos.Snapshot) (*n
 
 // UpdateObject Modify existing Snapshot object
 func (objectSet *SnapshotObjectSet) UpdateObject(id string, payload *nimbleos.Snapshot) (*nimbleos.Snapshot, error) {
-	resp, err := objectSet.Client.Put(snapshotPath, id, payload)
+	resp, err := objectSet.Client.Put(snapshotPath, id, payload, &nimbleos.Snapshot{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Snapshot), err
 }
 

--- a/pkg/client/tokens_object_set.go
+++ b/pkg/client/tokens_object_set.go
@@ -22,14 +22,9 @@ type TokenObjectSet struct {
 
 // CreateObject creates a new Token object
 func (objectSet *TokenObjectSet) CreateObject(payload *nimbleos.Token) (*nimbleos.Token, error) {
-	resp, err := objectSet.Client.Post(tokenPath, payload)
+	resp, err := objectSet.Client.Post(tokenPath, payload, &nimbleos.Token{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Token), err

--- a/pkg/client/user_groups_object_set.go
+++ b/pkg/client/user_groups_object_set.go
@@ -21,14 +21,9 @@ type UserGroupObjectSet struct {
 
 // CreateObject creates a new UserGroup object
 func (objectSet *UserGroupObjectSet) CreateObject(payload *nimbleos.UserGroup) (*nimbleos.UserGroup, error) {
-	resp, err := objectSet.Client.Post(userGroupPath, payload)
+	resp, err := objectSet.Client.Post(userGroupPath, payload, &nimbleos.UserGroup{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.UserGroup), err
@@ -36,15 +31,11 @@ func (objectSet *UserGroupObjectSet) CreateObject(payload *nimbleos.UserGroup) (
 
 // UpdateObject Modify existing UserGroup object
 func (objectSet *UserGroupObjectSet) UpdateObject(id string, payload *nimbleos.UserGroup) (*nimbleos.UserGroup, error) {
-	resp, err := objectSet.Client.Put(userGroupPath, id, payload)
+	resp, err := objectSet.Client.Put(userGroupPath, id, payload, &nimbleos.UserGroup{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.UserGroup), err
 }
 

--- a/pkg/client/user_policies_object_set.go
+++ b/pkg/client/user_policies_object_set.go
@@ -27,15 +27,11 @@ func (objectSet *UserPolicyObjectSet) CreateObject(payload *nimbleos.UserPolicy)
 
 // UpdateObject Modify existing UserPolicy object
 func (objectSet *UserPolicyObjectSet) UpdateObject(id string, payload *nimbleos.UserPolicy) (*nimbleos.UserPolicy, error) {
-	resp, err := objectSet.Client.Put(userPolicyPath, id, payload)
+	resp, err := objectSet.Client.Put(userPolicyPath, id, payload, &nimbleos.UserPolicy{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.UserPolicy), err
 }
 

--- a/pkg/client/users_object_set.go
+++ b/pkg/client/users_object_set.go
@@ -21,14 +21,9 @@ type UserObjectSet struct {
 
 // CreateObject creates a new User object
 func (objectSet *UserObjectSet) CreateObject(payload *nimbleos.User) (*nimbleos.User, error) {
-	resp, err := objectSet.Client.Post(userPath, payload)
+	resp, err := objectSet.Client.Post(userPath, payload, &nimbleos.User{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.User), err
@@ -36,15 +31,11 @@ func (objectSet *UserObjectSet) CreateObject(payload *nimbleos.User) (*nimbleos.
 
 // UpdateObject Modify existing User object
 func (objectSet *UserObjectSet) UpdateObject(id string, payload *nimbleos.User) (*nimbleos.User, error) {
-	resp, err := objectSet.Client.Put(userPath, id, payload)
+	resp, err := objectSet.Client.Put(userPath, id, payload, &nimbleos.User{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.User), err
 }
 

--- a/pkg/client/volume_collections_object_set.go
+++ b/pkg/client/volume_collections_object_set.go
@@ -22,14 +22,9 @@ type VolumeCollectionObjectSet struct {
 
 // CreateObject creates a new VolumeCollection object
 func (objectSet *VolumeCollectionObjectSet) CreateObject(payload *nimbleos.VolumeCollection) (*nimbleos.VolumeCollection, error) {
-	resp, err := objectSet.Client.Post(volumeCollectionPath, payload)
+	resp, err := objectSet.Client.Post(volumeCollectionPath, payload, &nimbleos.VolumeCollection{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.VolumeCollection), err
@@ -37,15 +32,11 @@ func (objectSet *VolumeCollectionObjectSet) CreateObject(payload *nimbleos.Volum
 
 // UpdateObject Modify existing VolumeCollection object
 func (objectSet *VolumeCollectionObjectSet) UpdateObject(id string, payload *nimbleos.VolumeCollection) (*nimbleos.VolumeCollection, error) {
-	resp, err := objectSet.Client.Put(volumeCollectionPath, id, payload)
+	resp, err := objectSet.Client.Put(volumeCollectionPath, id, payload, &nimbleos.VolumeCollection{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.VolumeCollection), err
 }
 

--- a/pkg/client/volumes_object_set.go
+++ b/pkg/client/volumes_object_set.go
@@ -22,14 +22,9 @@ type VolumeObjectSet struct {
 
 // CreateObject creates a new Volume object
 func (objectSet *VolumeObjectSet) CreateObject(payload *nimbleos.Volume) (*nimbleos.Volume, error) {
-	resp, err := objectSet.Client.Post(volumePath, payload)
+	resp, err := objectSet.Client.Post(volumePath, payload, &nimbleos.Volume{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Volume), err
@@ -37,15 +32,11 @@ func (objectSet *VolumeObjectSet) CreateObject(payload *nimbleos.Volume) (*nimbl
 
 // UpdateObject Modify existing Volume object
 func (objectSet *VolumeObjectSet) UpdateObject(id string, payload *nimbleos.Volume) (*nimbleos.Volume, error) {
-	resp, err := objectSet.Client.Put(volumePath, id, payload)
+	resp, err := objectSet.Client.Put(volumePath, id, payload, &nimbleos.Volume{})
 	if err != nil {
 		return nil, err
 	}
 
-	// null check
-	if resp == nil {
-		return nil, nil
-	}
 	return resp.(*nimbleos.Volume), err
 }
 

--- a/pkg/client/witnesses_object_set.go
+++ b/pkg/client/witnesses_object_set.go
@@ -22,14 +22,9 @@ type WitnessObjectSet struct {
 
 // CreateObject creates a new Witness object
 func (objectSet *WitnessObjectSet) CreateObject(payload *nimbleos.Witness) (*nimbleos.Witness, error) {
-	resp, err := objectSet.Client.Post(witnessPath, payload)
+	resp, err := objectSet.Client.Post(witnessPath, payload, &nimbleos.Witness{})
 	if err != nil {
 		return nil, err
-	}
-
-	// null check
-	if resp == nil {
-		return nil, nil
 	}
 
 	return resp.(*nimbleos.Witness), err


### PR DESCRIPTION
Bug 👍 SA-84
Problem : POST & PUT  function doesn't drop the object attribute if return nil by the Array .
Implementation 
Pass the pointer to concrete data type to POST & PUT function which would receive the response from the Array instead of using the same payload variable for request and response. 

Test:
vsingh:service vidhut.singh$ go test -v
=== RUN   TestVolumeServiceTestSuite
=== RUN   TestVolumeServiceTestSuite/TestGetNonExistentVolumeByID
--- PASS: TestVolumeServiceTestSuite (20.38s)
    --- PASS: TestVolumeServiceTestSuite/TestGetNonExistentVolumeByID (20.38s)
PASS
ok  	github.com/hpe-storage/nimble-golang-sdk/pkg/service	20.397s




Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>