### PR TITLE
SA-168, the SDKs doesn't allow to pass nil param to Get request

### DIFF
--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -6,11 +6,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
-	"strings"
-	"time"
 )
 
 const (
@@ -267,7 +268,7 @@ func (client *GroupMgmtClient) listPost(
 	params *param.GetParams,
 ) (interface{}, error) {
 	// build the url
-	url := fmt.Sprintf("%s/%s/detail", client.URL, path)
+	url := fmt.Sprintf("%s/%s/details", client.URL, path)
 	// Post it
 	response, err := client.Client.R().
 		SetQueryParams(queryParams).

--- a/pkg/client/ldap_domains_object_set.go
+++ b/pkg/client/ldap_domains_object_set.go
@@ -1,0 +1,157 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Manages the storage array's membership with LDAP servers.
+const (
+	ldapDomainPath = "ldap_domains"
+)
+
+// LdapDomainObjectSet
+type LdapDomainObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new LdapDomain object
+func (objectSet *LdapDomainObjectSet) CreateObject(payload *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Post(ldapDomainPath, payload, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// UpdateObject Modify existing LdapDomain object
+func (objectSet *LdapDomainObjectSet) UpdateObject(id string, payload *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Put(ldapDomainPath, id, payload, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// DeleteObject deletes the LdapDomain object with the specified ID
+func (objectSet *LdapDomainObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(ldapDomainPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a LdapDomain object with the given ID
+func (objectSet *LdapDomainObjectSet) GetObject(id string) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Get(ldapDomainPath, id, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// GetObjectList returns the list of LdapDomain objects
+func (objectSet *LdapDomainObjectSet) GetObjectList() ([]*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.List(ldapDomainPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildLdapDomainObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of LdapDomain objects using the given params query info
+func (objectSet *LdapDomainObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.LdapDomain, error) {
+	ldapDomainObjectSetResp, err := objectSet.Client.ListFromParams(ldapDomainPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildLdapDomainObjectSet(ldapDomainObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildLdapDomainObjectSet(response interface{}) []*nimbleos.LdapDomain {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.LdapDomain, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.LdapDomain{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}
+
+// List of supported actions on object sets
+
+// TestUser - Tests whether the user exist in the given LDAP Domain.
+func (objectSet *LdapDomainObjectSet) TestUser(id *string, user *string) (*nimbleos.NsLdapUser, error) {
+	testUserUri := ldapDomainPath
+	testUserUri = testUserUri + "/" + *id
+	testUserUri = testUserUri + "/actions/" + "test_user"
+
+	payload := &struct {
+		Id   *string `json:"id,omitempty"`
+		User *string `json:"user,omitempty"`
+	}{
+		id,
+		user,
+	}
+
+	resp, err := objectSet.Client.Post(testUserUri, payload, &nimbleos.NsLdapUser{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.NsLdapUser), err
+}
+
+// TestGroup - Tests whether the user group exist in the given LDAP Domain.
+func (objectSet *LdapDomainObjectSet) TestGroup(id *string, group *string) error {
+	testGroupUri := ldapDomainPath
+	testGroupUri = testGroupUri + "/" + *id
+	testGroupUri = testGroupUri + "/actions/" + "test_group"
+
+	payload := &struct {
+		Id    *string `json:"id,omitempty"`
+		Group *string `json:"group,omitempty"`
+	}{
+		id,
+		group,
+	}
+
+	_, err := objectSet.Client.Post(testGroupUri, payload, &nimbleos.LdapDomain{})
+	return err
+}
+
+// ReportStatus - Reports the LDAP connectivity status of the given LDAP ID.
+func (objectSet *LdapDomainObjectSet) ReportStatus(id *string) (*nimbleos.NsLdapReportStatusReturn, error) {
+	reportStatusUri := ldapDomainPath
+	reportStatusUri = reportStatusUri + "/" + *id
+	reportStatusUri = reportStatusUri + "/actions/" + "report_status"
+
+	payload := &struct {
+		Id *string `json:"id,omitempty"`
+	}{
+		id,
+	}
+
+	resp, err := objectSet.Client.Post(reportStatusUri, payload, &nimbleos.NsLdapReportStatusReturn{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.NsLdapReportStatusReturn), err
+}

--- a/pkg/client/object_set_factory.go
+++ b/pkg/client/object_set_factory.go
@@ -37,6 +37,13 @@ func (client *GroupMgmtClient) GetAlarmObjectSet() *AlarmObjectSet {
 	}
 }
 
+// SubscriptionObjectSet returns a reference to the Subscription object set
+func (client *GroupMgmtClient) GetSubscriptionObjectSet() *SubscriptionObjectSet {
+	return &SubscriptionObjectSet{
+		Client: client,
+	}
+}
+
 // VolumeObjectSet returns a reference to the Volume object set
 func (client *GroupMgmtClient) GetVolumeObjectSet() *VolumeObjectSet {
 	return &VolumeObjectSet{
@@ -282,6 +289,13 @@ func (client *GroupMgmtClient) GetVolumeCollectionObjectSet() *VolumeCollectionO
 	}
 }
 
+// SubscriberObjectSet returns a reference to the Subscriber object set
+func (client *GroupMgmtClient) GetSubscriberObjectSet() *SubscriberObjectSet {
+	return &SubscriberObjectSet{
+		Client: client,
+	}
+}
+
 // DiskObjectSet returns a reference to the Disk object set
 func (client *GroupMgmtClient) GetDiskObjectSet() *DiskObjectSet {
 	return &DiskObjectSet{
@@ -306,6 +320,13 @@ func (client *GroupMgmtClient) GetGroupObjectSet() *GroupObjectSet {
 // SoftwareVersionObjectSet returns a reference to the SoftwareVersion object set
 func (client *GroupMgmtClient) GetSoftwareVersionObjectSet() *SoftwareVersionObjectSet {
 	return &SoftwareVersionObjectSet{
+		Client: client,
+	}
+}
+
+// LdapDomainObjectSet returns a reference to the LdapDomain object set
+func (client *GroupMgmtClient) GetLdapDomainObjectSet() *LdapDomainObjectSet {
+	return &LdapDomainObjectSet{
 		Client: client,
 	}
 }

--- a/pkg/client/subscribers_object_set.go
+++ b/pkg/client/subscribers_object_set.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Subscribers are websocket based notification clients that can subscribe to interesting operations and events and recieve notifications whenever the subscribed to operations and
+// events happen on the array.
+const (
+	subscriberPath = "subscribers"
+)
+
+// SubscriberObjectSet
+type SubscriberObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new Subscriber object
+func (objectSet *SubscriberObjectSet) CreateObject(payload *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Post(subscriberPath, payload, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// UpdateObject Modify existing Subscriber object
+func (objectSet *SubscriberObjectSet) UpdateObject(id string, payload *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Put(subscriberPath, id, payload, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// DeleteObject deletes the Subscriber object with the specified ID
+func (objectSet *SubscriberObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(subscriberPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a Subscriber object with the given ID
+func (objectSet *SubscriberObjectSet) GetObject(id string) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Get(subscriberPath, id, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// GetObjectList returns the list of Subscriber objects
+func (objectSet *SubscriberObjectSet) GetObjectList() ([]*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.List(subscriberPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriberObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of Subscriber objects using the given params query info
+func (objectSet *SubscriberObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.Subscriber, error) {
+	subscriberObjectSetResp, err := objectSet.Client.ListFromParams(subscriberPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriberObjectSet(subscriberObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildSubscriberObjectSet(response interface{}) []*nimbleos.Subscriber {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.Subscriber, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.Subscriber{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}

--- a/pkg/client/subscriptions_object_set.go
+++ b/pkg/client/subscriptions_object_set.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Subscriptions represent the list of object types or alerts that a websocket client is interested in getting notifications for. Each subscription belongs to a single notification
+// client.
+const (
+	subscriptionPath = "subscriptions"
+)
+
+// SubscriptionObjectSet
+type SubscriptionObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new Subscription object
+func (objectSet *SubscriptionObjectSet) CreateObject(payload *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Post(subscriptionPath, payload, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscription), err
+}
+
+// UpdateObject Modify existing Subscription object
+func (objectSet *SubscriptionObjectSet) UpdateObject(id string, payload *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Put(subscriptionPath, id, payload, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscription), err
+}
+
+// DeleteObject deletes the Subscription object with the specified ID
+func (objectSet *SubscriptionObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(subscriptionPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a Subscription object with the given ID
+func (objectSet *SubscriptionObjectSet) GetObject(id string) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Get(subscriptionPath, id, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.Subscription), err
+}
+
+// GetObjectList returns the list of Subscription objects
+func (objectSet *SubscriptionObjectSet) GetObjectList() ([]*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.List(subscriptionPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriptionObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of Subscription objects using the given params query info
+func (objectSet *SubscriptionObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.Subscription, error) {
+	subscriptionObjectSetResp, err := objectSet.Client.ListFromParams(subscriptionPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriptionObjectSet(subscriptionObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildSubscriptionObjectSet(response interface{}) []*nimbleos.Subscription {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.Subscription, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.Subscription{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}

--- a/pkg/client/v1/nimbleos/array.go
+++ b/pkg/client/v1/nimbleos/array.go
@@ -121,7 +121,7 @@ type Array struct {
 	IsSupportedHwConfig *bool `json:"is_supported_hw_config,omitempty"`
 	// GigNicPortCount - Count of 1G NIC Ports installed on the array.
 	GigNicPortCount *int64 `json:"gig_nic_port_count,omitempty"`
-	// TenGigSfpNicPortCount - Count of 10G SFP NIC Ports installed on the array.
+	// TenGigSfpNicPortCount - Count of SFP NIC Ports installed on the array capable of 10G, 25G or 100G speeds.
 	TenGigSfpNicPortCount *int64 `json:"ten_gig_sfp_nic_port_count,omitempty"`
 	// TenGigTNicPortCount - Count of 10G BaseT NIC Ports installed on the array.
 	TenGigTNicPortCount *int64 `json:"ten_gig_t_nic_port_count,omitempty"`

--- a/pkg/client/v1/nimbleos/controller.go
+++ b/pkg/client/v1/nimbleos/controller.go
@@ -12,6 +12,7 @@ func init() {
 	ArrayNamefield := "array_name"
 	ArrayIdfield := "array_id"
 	Serialfield := "serial"
+	Modelfield := "model"
 	Hostnamefield := "hostname"
 	SupportAddressfield := "support_address"
 	SupportNetmaskfield := "support_netmask"
@@ -23,6 +24,7 @@ func init() {
 		ArrayName:      &ArrayNamefield,
 		ArrayId:        &ArrayIdfield,
 		Serial:         &Serialfield,
+		Model:          &Modelfield,
 		Hostname:       &Hostnamefield,
 		SupportAddress: &SupportAddressfield,
 		SupportNetmask: &SupportNetmaskfield,
@@ -43,6 +45,8 @@ type Controller struct {
 	PartialResponseOk *bool `json:"partial_response_ok,omitempty"`
 	// Serial - Serial number for this controller.
 	Serial *string `json:"serial,omitempty"`
+	// Model - Model of this controller.
+	Model *string `json:"model,omitempty"`
 	// Hostname - Host name for the controller.
 	Hostname *string `json:"hostname,omitempty"`
 	// SupportAddress - IP address used for support.

--- a/pkg/client/v1/nimbleos/group.go
+++ b/pkg/client/v1/nimbleos/group.go
@@ -159,6 +159,8 @@ type Group struct {
 	SyslogdServer *string `json:"syslogd_server,omitempty"`
 	// SyslogdPort - Port number for syslogd server.
 	SyslogdPort *int64 `json:"syslogd_port,omitempty"`
+	// SyslogdServers - Hostname and/or port of the syslogd servers.
+	SyslogdServers []*NsFqdnOrIpAndPortObject `json:"syslogd_servers,omitempty"`
 	// VvolEnabled - Are vvols enabled on this group.
 	VvolEnabled *bool `json:"vvol_enabled,omitempty"`
 	// IscsiEnabled - Whether iSCSI is enabled on this group.

--- a/pkg/client/v1/nimbleos/ldap_domain.go
+++ b/pkg/client/v1/nimbleos/ldap_domain.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package nimbleos
+
+// LdapDomain - Manages the storage array's membership with LDAP servers.
+// Export LdapDomainFields for advance operations like search filter etc.
+var LdapDomainFields *LdapDomain
+
+func init() {
+	IDfield := "id"
+	DomainNamefield := "domain_name"
+	DomainDescriptionfield := "domain_description"
+	BindUserfield := "bind_user"
+	BindPasswordfield := "bind_password"
+	BaseDnfield := "base_dn"
+	UserSearchFilterfield := "user_search_filter"
+	GroupSearchFilterfield := "group_search_filter"
+
+	LdapDomainFields = &LdapDomain{
+		ID:                &IDfield,
+		DomainName:        &DomainNamefield,
+		DomainDescription: &DomainDescriptionfield,
+		BindUser:          &BindUserfield,
+		BindPassword:      &BindPasswordfield,
+		BaseDn:            &BaseDnfield,
+		UserSearchFilter:  &UserSearchFilterfield,
+		GroupSearchFilter: &GroupSearchFilterfield,
+	}
+}
+
+type LdapDomain struct {
+	// ID - Identifier for the LDAP Domain.
+	ID *string `json:"id,omitempty"`
+	// DomainName - Domain name.
+	DomainName *string `json:"domain_name,omitempty"`
+	// DomainDescription - Description of the domain.
+	DomainDescription *string `json:"domain_description,omitempty"`
+	// DomainEnabled - Indicates whether the LDAP domain is currently active or not.
+	DomainEnabled *bool `json:"domain_enabled,omitempty"`
+	// ServerUriList - A set of up to 3 LDAP URIs.
+	ServerUriList []*string `json:"server_uri_list,omitempty"`
+	// BindUser - Full Distinguished Name of LDAP admin user. If empty, attempt to bind anonymously.
+	BindUser *string `json:"bind_user,omitempty"`
+	// BindPassword - Password for the Full Distinguished Name of LDAP admin user.  This parameter is mandatory if the bind_user is given.
+	BindPassword *string `json:"bind_password,omitempty"`
+	// BaseDn - The Distinguished Name of the base object from which to start all searches.
+	BaseDn *string `json:"base_dn,omitempty"`
+	// UserSearchFilter - Limit the results returned based on specific search criteria.
+	UserSearchFilter *string `json:"user_search_filter,omitempty"`
+	// UserSearchBaseList - A set of upto 10 Relative Distinguished Names, relative to the Base DN, from which to search for User objects.
+	UserSearchBaseList []*string `json:"user_search_base_list,omitempty"`
+	// GroupSearchFilter - Limit the results returned based on specific search criteria.
+	GroupSearchFilter *string `json:"group_search_filter,omitempty"`
+	// GroupSearchBaseList - A set of upto 10 Relative Distinguished Names, relative to the Base DN, from which to search for Group objects.
+	GroupSearchBaseList []*string `json:"group_search_base_list,omitempty"`
+	// SchemaType - Enum values are OpenLDAP or AD.
+	SchemaType *NsLdapSchemaType `json:"schema_type,omitempty"`
+}

--- a/pkg/client/v1/nimbleos/ns_array_upgrade.go
+++ b/pkg/client/v1/nimbleos/ns_array_upgrade.go
@@ -7,8 +7,13 @@ package nimbleos
 var NsArrayUpgradeFields *NsArrayUpgrade
 
 func init() {
+	CtrlrAPortListfield := "ctrlr_a_port_list"
+	CtrlrBPortListfield := "ctrlr_b_port_list"
 
-	NsArrayUpgradeFields = &NsArrayUpgrade{}
+	NsArrayUpgradeFields = &NsArrayUpgrade{
+		CtrlrAPortList: &CtrlrAPortListfield,
+		CtrlrBPortList: &CtrlrBPortListfield,
+	}
 }
 
 type NsArrayUpgrade struct {
@@ -18,6 +23,12 @@ type NsArrayUpgrade struct {
 	State *NsArrayUpgradeState `json:"state,omitempty"`
 	// Stage - Array upgrade stage.
 	Stage *NsArrayUpgradeStage `json:"stage,omitempty"`
+	// CtrlrAPortList - Comma-separated list of array upgrade port names for controller A.
+	CtrlrAPortList *string `json:"ctrlr_a_port_list,omitempty"`
+	// CtrlrBPortList - Comma-separated list of array upgrade port names for controller B.
+	CtrlrBPortList *string `json:"ctrlr_b_port_list,omitempty"`
 	// Messages - List of error or info messages.
 	Messages []*NsErrorWithArguments `json:"messages,omitempty"`
+	// Metadata - Key-value pairs that augment an array upgrade attributes.
+	Metadata []*NsKeyValue `json:"metadata,omitempty"`
 }

--- a/pkg/client/v1/nimbleos/ns_array_upgrade_stage.go
+++ b/pkg/client/v1/nimbleos/ns_array_upgrade_stage.go
@@ -6,17 +6,44 @@ package nimbleos
 type NsArrayUpgradeStage string
 
 const (
-	cNsArrayUpgradeStagePrepare NsArrayUpgradeStage = "prepare"
-	cNsArrayUpgradeStageFinish  NsArrayUpgradeStage = "finish"
-	cNsArrayUpgradeStageNone    NsArrayUpgradeStage = "none"
+	cNsArrayUpgradeStagePrepare         NsArrayUpgradeStage = "prepare"
+	cNsArrayUpgradeStageMixedGeneration NsArrayUpgradeStage = "mixed_generation"
+	cNsArrayUpgradeStageFinalUpgrade    NsArrayUpgradeStage = "final_upgrade"
+	cNsArrayUpgradeStageDisableMirror   NsArrayUpgradeStage = "disable_mirror"
+	cNsArrayUpgradeStageDriveMigration  NsArrayUpgradeStage = "drive_migration"
+	cNsArrayUpgradeStageEnableMirror    NsArrayUpgradeStage = "enable_mirror"
+	cNsArrayUpgradeStageFinish          NsArrayUpgradeStage = "finish"
+	cNsArrayUpgradeStageNone            NsArrayUpgradeStage = "none"
+	cNsArrayUpgradeStageNewGeneration   NsArrayUpgradeStage = "new_generation"
 )
 
 var pNsArrayUpgradeStagePrepare NsArrayUpgradeStage
+var pNsArrayUpgradeStageMixedGeneration NsArrayUpgradeStage
+var pNsArrayUpgradeStageFinalUpgrade NsArrayUpgradeStage
+var pNsArrayUpgradeStageDisableMirror NsArrayUpgradeStage
+var pNsArrayUpgradeStageDriveMigration NsArrayUpgradeStage
+var pNsArrayUpgradeStageEnableMirror NsArrayUpgradeStage
 var pNsArrayUpgradeStageFinish NsArrayUpgradeStage
 var pNsArrayUpgradeStageNone NsArrayUpgradeStage
+var pNsArrayUpgradeStageNewGeneration NsArrayUpgradeStage
 
 // NsArrayUpgradeStagePrepare enum exports
 var NsArrayUpgradeStagePrepare *NsArrayUpgradeStage
+
+// NsArrayUpgradeStageMixedGeneration enum exports
+var NsArrayUpgradeStageMixedGeneration *NsArrayUpgradeStage
+
+// NsArrayUpgradeStageFinalUpgrade enum exports
+var NsArrayUpgradeStageFinalUpgrade *NsArrayUpgradeStage
+
+// NsArrayUpgradeStageDisableMirror enum exports
+var NsArrayUpgradeStageDisableMirror *NsArrayUpgradeStage
+
+// NsArrayUpgradeStageDriveMigration enum exports
+var NsArrayUpgradeStageDriveMigration *NsArrayUpgradeStage
+
+// NsArrayUpgradeStageEnableMirror enum exports
+var NsArrayUpgradeStageEnableMirror *NsArrayUpgradeStage
 
 // NsArrayUpgradeStageFinish enum exports
 var NsArrayUpgradeStageFinish *NsArrayUpgradeStage
@@ -24,14 +51,35 @@ var NsArrayUpgradeStageFinish *NsArrayUpgradeStage
 // NsArrayUpgradeStageNone enum exports
 var NsArrayUpgradeStageNone *NsArrayUpgradeStage
 
+// NsArrayUpgradeStageNewGeneration enum exports
+var NsArrayUpgradeStageNewGeneration *NsArrayUpgradeStage
+
 func init() {
 	pNsArrayUpgradeStagePrepare = cNsArrayUpgradeStagePrepare
 	NsArrayUpgradeStagePrepare = &pNsArrayUpgradeStagePrepare
+
+	pNsArrayUpgradeStageMixedGeneration = cNsArrayUpgradeStageMixedGeneration
+	NsArrayUpgradeStageMixedGeneration = &pNsArrayUpgradeStageMixedGeneration
+
+	pNsArrayUpgradeStageFinalUpgrade = cNsArrayUpgradeStageFinalUpgrade
+	NsArrayUpgradeStageFinalUpgrade = &pNsArrayUpgradeStageFinalUpgrade
+
+	pNsArrayUpgradeStageDisableMirror = cNsArrayUpgradeStageDisableMirror
+	NsArrayUpgradeStageDisableMirror = &pNsArrayUpgradeStageDisableMirror
+
+	pNsArrayUpgradeStageDriveMigration = cNsArrayUpgradeStageDriveMigration
+	NsArrayUpgradeStageDriveMigration = &pNsArrayUpgradeStageDriveMigration
+
+	pNsArrayUpgradeStageEnableMirror = cNsArrayUpgradeStageEnableMirror
+	NsArrayUpgradeStageEnableMirror = &pNsArrayUpgradeStageEnableMirror
 
 	pNsArrayUpgradeStageFinish = cNsArrayUpgradeStageFinish
 	NsArrayUpgradeStageFinish = &pNsArrayUpgradeStageFinish
 
 	pNsArrayUpgradeStageNone = cNsArrayUpgradeStageNone
 	NsArrayUpgradeStageNone = &pNsArrayUpgradeStageNone
+
+	pNsArrayUpgradeStageNewGeneration = cNsArrayUpgradeStageNewGeneration
+	NsArrayUpgradeStageNewGeneration = &pNsArrayUpgradeStageNewGeneration
 
 }

--- a/pkg/client/v1/nimbleos/ns_array_upgrade_type.go
+++ b/pkg/client/v1/nimbleos/ns_array_upgrade_type.go
@@ -8,10 +8,12 @@ type NsArrayUpgradeType string
 const (
 	cNsArrayUpgradeTypeOffline NsArrayUpgradeType = "offline"
 	cNsArrayUpgradeTypeInvalid NsArrayUpgradeType = "invalid"
+	cNsArrayUpgradeTypeOnline  NsArrayUpgradeType = "online"
 )
 
 var pNsArrayUpgradeTypeOffline NsArrayUpgradeType
 var pNsArrayUpgradeTypeInvalid NsArrayUpgradeType
+var pNsArrayUpgradeTypeOnline NsArrayUpgradeType
 
 // NsArrayUpgradeTypeOffline enum exports
 var NsArrayUpgradeTypeOffline *NsArrayUpgradeType
@@ -19,11 +21,17 @@ var NsArrayUpgradeTypeOffline *NsArrayUpgradeType
 // NsArrayUpgradeTypeInvalid enum exports
 var NsArrayUpgradeTypeInvalid *NsArrayUpgradeType
 
+// NsArrayUpgradeTypeOnline enum exports
+var NsArrayUpgradeTypeOnline *NsArrayUpgradeType
+
 func init() {
 	pNsArrayUpgradeTypeOffline = cNsArrayUpgradeTypeOffline
 	NsArrayUpgradeTypeOffline = &pNsArrayUpgradeTypeOffline
 
 	pNsArrayUpgradeTypeInvalid = cNsArrayUpgradeTypeInvalid
 	NsArrayUpgradeTypeInvalid = &pNsArrayUpgradeTypeInvalid
+
+	pNsArrayUpgradeTypeOnline = cNsArrayUpgradeTypeOnline
+	NsArrayUpgradeTypeOnline = &pNsArrayUpgradeTypeOnline
 
 }

--- a/pkg/client/v1/nimbleos/ns_domain_type.go
+++ b/pkg/client/v1/nimbleos/ns_domain_type.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+package nimbleos
+
+// Golang package for NsDomainType Enum.
+
+type NsDomainType string
+
+const (
+	cNsDomainTypeAd    NsDomainType = "ad"
+	cNsDomainTypeLdap  NsDomainType = "ldap"
+	cNsDomainTypeLocal NsDomainType = "local"
+)
+
+var pNsDomainTypeAd NsDomainType
+var pNsDomainTypeLdap NsDomainType
+var pNsDomainTypeLocal NsDomainType
+
+// NsDomainTypeAd enum exports
+var NsDomainTypeAd *NsDomainType
+
+// NsDomainTypeLdap enum exports
+var NsDomainTypeLdap *NsDomainType
+
+// NsDomainTypeLocal enum exports
+var NsDomainTypeLocal *NsDomainType
+
+func init() {
+	pNsDomainTypeAd = cNsDomainTypeAd
+	NsDomainTypeAd = &pNsDomainTypeAd
+
+	pNsDomainTypeLdap = cNsDomainTypeLdap
+	NsDomainTypeLdap = &pNsDomainTypeLdap
+
+	pNsDomainTypeLocal = cNsDomainTypeLocal
+	NsDomainTypeLocal = &pNsDomainTypeLocal
+
+}

--- a/pkg/client/v1/nimbleos/ns_error.go
+++ b/pkg/client/v1/nimbleos/ns_error.go
@@ -13,6 +13,7 @@ const (
 	cNsErrorSmAppserverNotFound                           NsError = "SM_appserver_not_found"
 	cNsErrorSmFolderReplPartner                           NsError = "SM_folder_repl_partner"
 	cNsErrorSmArrayPoolMember                             NsError = "SM_array_pool_member"
+	cNsErrorSmErrInvalidArg                               NsError = "SM_err_invalid_arg"
 	cNsErrorSmErrShelfCreateRfail                         NsError = "SM_err_shelf_create_rfail"
 	cNsErrorSmStarterVolCreate                            NsError = "SM_starter_vol_create"
 	cNsErrorSmInvalidNetconfigName                        NsError = "SM_invalid_netconfig_name"
@@ -40,6 +41,7 @@ const (
 	cNsErrorSmFolderUsageLimitOverPoolCapacity            NsError = "SM_folder_usage_limit_over_pool_capacity"
 	cNsErrorSmEnomem                                      NsError = "SM_enomem"
 	cNsErrorSmErrShelfNotInuse                            NsError = "SM_err_shelf_not_inuse"
+	cNsErrorSmErrLdapAdConflict                           NsError = "SM_err_ldap_ad_conflict"
 	cNsErrorSmErrShelfPreactivationMfrErr                 NsError = "SM_err_shelf_preactivation_mfr_err"
 	cNsErrorSmUpdateBusy                                  NsError = "SM_update_busy"
 	cNsErrorSmProtpolInvalidAppSync                       NsError = "SM_protpol_invalid_app_sync"
@@ -56,6 +58,7 @@ const (
 	cNsErrorSmErrGroupMergeEventsPending                  NsError = "SM_err_group_merge_events_pending"
 	cNsErrorSmSrepNameConflictVols                        NsError = "SM_srep_name_conflict_vols"
 	cNsErrorSmPoolPartnerResumeUnsup                      NsError = "SM_pool_partner_resume_unsup"
+	cNsErrorSmErrLdapAlreadyExists                        NsError = "SM_err_ldap_already_exists"
 	cNsErrorSmArrayNotFound                               NsError = "SM_array_not_found"
 	cNsErrorSmNoIscsiHardware                             NsError = "SM_no_iscsi_hardware"
 	cNsErrorSmEnospc                                      NsError = "SM_enospc"
@@ -158,6 +161,7 @@ const (
 	cNsErrorSmZeroVlanIdForTaggedAssignment               NsError = "SM_zero_vlan_id_for_tagged_assignment"
 	cNsErrorSmNoActionFound                               NsError = "SM_no_action_found"
 	cNsErrorSmSyncReplUnconfigureInProgress               NsError = "SM_sync_repl_unconfigure_in_progress"
+	cNsErrorSmErrMissingArg                               NsError = "SM_err_missing_arg"
 	cNsErrorSmVolThickProvMoveInvalid                     NsError = "SM_vol_thick_prov_move_invalid"
 	cNsErrorSmMissingAdvancedCriteriaConstructor          NsError = "SM_missing_advanced_criteria_constructor"
 	cNsErrorSmPoolUnknown                                 NsError = "SM_pool_unknown"
@@ -248,6 +252,7 @@ const (
 	cNsErrorSmVolHasOnlineSnap                            NsError = "SM_vol_has_online_snap"
 	cNsErrorSmInvalidDataIp                               NsError = "SM_invalid_data_ip"
 	cNsErrorSmPoolVolmvEinprog                            NsError = "SM_pool_volmv_einprog"
+	cNsErrorSmErrLdapBindPasswordNoUser                   NsError = "SM_err_ldap_bind_password_no_user"
 	cNsErrorSmNoDataIpOnMgmtPlusData                      NsError = "SM_no_data_ip_on_mgmt_plus_data"
 	cNsErrorSmConflictingAclLun                           NsError = "SM_conflicting_acl_lun"
 	cNsErrorSmVpCreatedIgrp                               NsError = "SM_vp_created_igrp"
@@ -481,6 +486,7 @@ const (
 	cNsErrorSmInvalidFolder                               NsError = "SM_invalid_folder"
 	cNsErrorSmSrvUpdatePrecheckArray                      NsError = "SM_srv_update_precheck_array"
 	cNsErrorSmGatewayNotInSubnets                         NsError = "SM_gateway_not_in_subnets"
+	cNsErrorSmErrLdapBindUserNoPassword                   NsError = "SM_err_ldap_bind_user_no_password"
 	cNsErrorSmDeprecatedPerfpol                           NsError = "SM_deprecated_perfpol"
 	cNsErrorSmTakeoverSplitBrain                          NsError = "SM_takeover_split_brain"
 	cNsErrorSmPeIgroupProtocolMismatched                  NsError = "SM_pe_igroup_protocol_mismatched"
@@ -519,6 +525,7 @@ var pNsErrorSmExtTrigSchedNotPresent NsError
 var pNsErrorSmAppserverNotFound NsError
 var pNsErrorSmFolderReplPartner NsError
 var pNsErrorSmArrayPoolMember NsError
+var pNsErrorSmErrInvalidArg NsError
 var pNsErrorSmErrShelfCreateRfail NsError
 var pNsErrorSmStarterVolCreate NsError
 var pNsErrorSmInvalidNetconfigName NsError
@@ -546,6 +553,7 @@ var pNsErrorSmMultiArrayWithoutAutomaticConnectionMethod NsError
 var pNsErrorSmFolderUsageLimitOverPoolCapacity NsError
 var pNsErrorSmEnomem NsError
 var pNsErrorSmErrShelfNotInuse NsError
+var pNsErrorSmErrLdapAdConflict NsError
 var pNsErrorSmErrShelfPreactivationMfrErr NsError
 var pNsErrorSmUpdateBusy NsError
 var pNsErrorSmProtpolInvalidAppSync NsError
@@ -562,6 +570,7 @@ var pNsErrorSmArrayNotReachable NsError
 var pNsErrorSmErrGroupMergeEventsPending NsError
 var pNsErrorSmSrepNameConflictVols NsError
 var pNsErrorSmPoolPartnerResumeUnsup NsError
+var pNsErrorSmErrLdapAlreadyExists NsError
 var pNsErrorSmArrayNotFound NsError
 var pNsErrorSmNoIscsiHardware NsError
 var pNsErrorSmEnospc NsError
@@ -664,6 +673,7 @@ var pNsErrorSmDuplicateSubnetLabel NsError
 var pNsErrorSmZeroVlanIdForTaggedAssignment NsError
 var pNsErrorSmNoActionFound NsError
 var pNsErrorSmSyncReplUnconfigureInProgress NsError
+var pNsErrorSmErrMissingArg NsError
 var pNsErrorSmVolThickProvMoveInvalid NsError
 var pNsErrorSmMissingAdvancedCriteriaConstructor NsError
 var pNsErrorSmPoolUnknown NsError
@@ -754,6 +764,7 @@ var pNsErrorSmPoolUpdateInvalArrays NsError
 var pNsErrorSmVolHasOnlineSnap NsError
 var pNsErrorSmInvalidDataIp NsError
 var pNsErrorSmPoolVolmvEinprog NsError
+var pNsErrorSmErrLdapBindPasswordNoUser NsError
 var pNsErrorSmNoDataIpOnMgmtPlusData NsError
 var pNsErrorSmConflictingAclLun NsError
 var pNsErrorSmVpCreatedIgrp NsError
@@ -987,6 +998,7 @@ var pNsErrorSmReplPartnerNameMismatch NsError
 var pNsErrorSmInvalidFolder NsError
 var pNsErrorSmSrvUpdatePrecheckArray NsError
 var pNsErrorSmGatewayNotInSubnets NsError
+var pNsErrorSmErrLdapBindUserNoPassword NsError
 var pNsErrorSmDeprecatedPerfpol NsError
 var pNsErrorSmTakeoverSplitBrain NsError
 var pNsErrorSmPeIgroupProtocolMismatched NsError
@@ -1037,6 +1049,9 @@ var NsErrorSmFolderReplPartner *NsError
 
 // NsErrorSmArrayPoolMember enum exports
 var NsErrorSmArrayPoolMember *NsError
+
+// NsErrorSmErrInvalidArg enum exports
+var NsErrorSmErrInvalidArg *NsError
 
 // NsErrorSmErrShelfCreateRfail enum exports
 var NsErrorSmErrShelfCreateRfail *NsError
@@ -1119,6 +1134,9 @@ var NsErrorSmEnomem *NsError
 // NsErrorSmErrShelfNotInuse enum exports
 var NsErrorSmErrShelfNotInuse *NsError
 
+// NsErrorSmErrLdapAdConflict enum exports
+var NsErrorSmErrLdapAdConflict *NsError
+
 // NsErrorSmErrShelfPreactivationMfrErr enum exports
 var NsErrorSmErrShelfPreactivationMfrErr *NsError
 
@@ -1166,6 +1184,9 @@ var NsErrorSmSrepNameConflictVols *NsError
 
 // NsErrorSmPoolPartnerResumeUnsup enum exports
 var NsErrorSmPoolPartnerResumeUnsup *NsError
+
+// NsErrorSmErrLdapAlreadyExists enum exports
+var NsErrorSmErrLdapAlreadyExists *NsError
 
 // NsErrorSmArrayNotFound enum exports
 var NsErrorSmArrayNotFound *NsError
@@ -1473,6 +1494,9 @@ var NsErrorSmNoActionFound *NsError
 // NsErrorSmSyncReplUnconfigureInProgress enum exports
 var NsErrorSmSyncReplUnconfigureInProgress *NsError
 
+// NsErrorSmErrMissingArg enum exports
+var NsErrorSmErrMissingArg *NsError
+
 // NsErrorSmVolThickProvMoveInvalid enum exports
 var NsErrorSmVolThickProvMoveInvalid *NsError
 
@@ -1742,6 +1766,9 @@ var NsErrorSmInvalidDataIp *NsError
 
 // NsErrorSmPoolVolmvEinprog enum exports
 var NsErrorSmPoolVolmvEinprog *NsError
+
+// NsErrorSmErrLdapBindPasswordNoUser enum exports
+var NsErrorSmErrLdapBindPasswordNoUser *NsError
 
 // NsErrorSmNoDataIpOnMgmtPlusData enum exports
 var NsErrorSmNoDataIpOnMgmtPlusData *NsError
@@ -2442,6 +2469,9 @@ var NsErrorSmSrvUpdatePrecheckArray *NsError
 // NsErrorSmGatewayNotInSubnets enum exports
 var NsErrorSmGatewayNotInSubnets *NsError
 
+// NsErrorSmErrLdapBindUserNoPassword enum exports
+var NsErrorSmErrLdapBindUserNoPassword *NsError
+
 // NsErrorSmDeprecatedPerfpol enum exports
 var NsErrorSmDeprecatedPerfpol *NsError
 
@@ -2551,6 +2581,9 @@ func init() {
 	pNsErrorSmArrayPoolMember = cNsErrorSmArrayPoolMember
 	NsErrorSmArrayPoolMember = &pNsErrorSmArrayPoolMember
 
+	pNsErrorSmErrInvalidArg = cNsErrorSmErrInvalidArg
+	NsErrorSmErrInvalidArg = &pNsErrorSmErrInvalidArg
+
 	pNsErrorSmErrShelfCreateRfail = cNsErrorSmErrShelfCreateRfail
 	NsErrorSmErrShelfCreateRfail = &pNsErrorSmErrShelfCreateRfail
 
@@ -2632,6 +2665,9 @@ func init() {
 	pNsErrorSmErrShelfNotInuse = cNsErrorSmErrShelfNotInuse
 	NsErrorSmErrShelfNotInuse = &pNsErrorSmErrShelfNotInuse
 
+	pNsErrorSmErrLdapAdConflict = cNsErrorSmErrLdapAdConflict
+	NsErrorSmErrLdapAdConflict = &pNsErrorSmErrLdapAdConflict
+
 	pNsErrorSmErrShelfPreactivationMfrErr = cNsErrorSmErrShelfPreactivationMfrErr
 	NsErrorSmErrShelfPreactivationMfrErr = &pNsErrorSmErrShelfPreactivationMfrErr
 
@@ -2679,6 +2715,9 @@ func init() {
 
 	pNsErrorSmPoolPartnerResumeUnsup = cNsErrorSmPoolPartnerResumeUnsup
 	NsErrorSmPoolPartnerResumeUnsup = &pNsErrorSmPoolPartnerResumeUnsup
+
+	pNsErrorSmErrLdapAlreadyExists = cNsErrorSmErrLdapAlreadyExists
+	NsErrorSmErrLdapAlreadyExists = &pNsErrorSmErrLdapAlreadyExists
 
 	pNsErrorSmArrayNotFound = cNsErrorSmArrayNotFound
 	NsErrorSmArrayNotFound = &pNsErrorSmArrayNotFound
@@ -2986,6 +3025,9 @@ func init() {
 	pNsErrorSmSyncReplUnconfigureInProgress = cNsErrorSmSyncReplUnconfigureInProgress
 	NsErrorSmSyncReplUnconfigureInProgress = &pNsErrorSmSyncReplUnconfigureInProgress
 
+	pNsErrorSmErrMissingArg = cNsErrorSmErrMissingArg
+	NsErrorSmErrMissingArg = &pNsErrorSmErrMissingArg
+
 	pNsErrorSmVolThickProvMoveInvalid = cNsErrorSmVolThickProvMoveInvalid
 	NsErrorSmVolThickProvMoveInvalid = &pNsErrorSmVolThickProvMoveInvalid
 
@@ -3255,6 +3297,9 @@ func init() {
 
 	pNsErrorSmPoolVolmvEinprog = cNsErrorSmPoolVolmvEinprog
 	NsErrorSmPoolVolmvEinprog = &pNsErrorSmPoolVolmvEinprog
+
+	pNsErrorSmErrLdapBindPasswordNoUser = cNsErrorSmErrLdapBindPasswordNoUser
+	NsErrorSmErrLdapBindPasswordNoUser = &pNsErrorSmErrLdapBindPasswordNoUser
 
 	pNsErrorSmNoDataIpOnMgmtPlusData = cNsErrorSmNoDataIpOnMgmtPlusData
 	NsErrorSmNoDataIpOnMgmtPlusData = &pNsErrorSmNoDataIpOnMgmtPlusData
@@ -3954,6 +3999,9 @@ func init() {
 
 	pNsErrorSmGatewayNotInSubnets = cNsErrorSmGatewayNotInSubnets
 	NsErrorSmGatewayNotInSubnets = &pNsErrorSmGatewayNotInSubnets
+
+	pNsErrorSmErrLdapBindUserNoPassword = cNsErrorSmErrLdapBindUserNoPassword
+	NsErrorSmErrLdapBindUserNoPassword = &pNsErrorSmErrLdapBindUserNoPassword
 
 	pNsErrorSmDeprecatedPerfpol = cNsErrorSmDeprecatedPerfpol
 	NsErrorSmDeprecatedPerfpol = &pNsErrorSmDeprecatedPerfpol

--- a/pkg/client/v1/nimbleos/ns_fqdn_or_ip_and_port_object.go
+++ b/pkg/client/v1/nimbleos/ns_fqdn_or_ip_and_port_object.go
@@ -1,0 +1,22 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package nimbleos
+
+// NsFqdnOrIpAndPortObject - Object wrapper of Fqdn/IP Address and Port numbers.
+// Export NsFqdnOrIpAndPortObjectFields for advance operations like search filter etc.
+var NsFqdnOrIpAndPortObjectFields *NsFqdnOrIpAndPortObject
+
+func init() {
+	SyslogServerfield := "syslog_server"
+
+	NsFqdnOrIpAndPortObjectFields = &NsFqdnOrIpAndPortObject{
+		SyslogServer: &SyslogServerfield,
+	}
+}
+
+type NsFqdnOrIpAndPortObject struct {
+	// SyslogServer - A Fqdn/IP Address.
+	SyslogServer *string `json:"syslog_server,omitempty"`
+	// SyslogPort - Syslog port number.
+	SyslogPort *int64 `json:"syslog_port,omitempty"`
+}

--- a/pkg/client/v1/nimbleos/ns_group_merge_return.go
+++ b/pkg/client/v1/nimbleos/ns_group_merge_return.go
@@ -79,4 +79,6 @@ type NsGroupMergeReturn struct {
 	ValidationError []*NsErrorWithArguments `json:"validation_error,omitempty"`
 	// ValidationErrorMsg - Detailed error message.
 	ValidationErrorMsg *string `json:"validation_error_msg,omitempty"`
+	// WarningList - List of warning messages.
+	WarningList []*string `json:"warning_list,omitempty"`
 }

--- a/pkg/client/v1/nimbleos/ns_ldap_report_status_return.go
+++ b/pkg/client/v1/nimbleos/ns_ldap_report_status_return.go
@@ -1,0 +1,26 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package nimbleos
+
+// NsLdapReportStatusReturn - A report of the current LDAP status for the group.
+// Export NsLdapReportStatusReturnFields for advance operations like search filter etc.
+var NsLdapReportStatusReturnFields *NsLdapReportStatusReturn
+
+func init() {
+	RemoteServiceStatusfield := "remote_service_status"
+
+	NsLdapReportStatusReturnFields = &NsLdapReportStatusReturn{
+		RemoteServiceStatus: &RemoteServiceStatusfield,
+	}
+}
+
+type NsLdapReportStatusReturn struct {
+	// Enabled - Whether the LDAP domain enabled on the group.
+	Enabled *bool `json:"enabled,omitempty"`
+	// LocalServiceStatusGood - Whether the (group's) local LDAP service running in a good state.
+	LocalServiceStatusGood *bool `json:"local_service_status_good,omitempty"`
+	// RemoteServiceStatusGood - Whether there appears to be an issue with the remote LDAP service. For example, misconfigured/expired TLS certificates.
+	RemoteServiceStatusGood *bool `json:"remote_service_status_good,omitempty"`
+	// RemoteServiceStatus - If the remote service status is not good then this provides a descriptive status message.
+	RemoteServiceStatus *string `json:"remote_service_status,omitempty"`
+}

--- a/pkg/client/v1/nimbleos/ns_ldap_schema_type.go
+++ b/pkg/client/v1/nimbleos/ns_ldap_schema_type.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+package nimbleos
+
+// Golang package for NsLdapSchemaType Enum.
+
+type NsLdapSchemaType string
+
+const (
+	cNsLdapSchemaTypeOpenldap NsLdapSchemaType = "OpenLDAP"
+	cNsLdapSchemaTypeAd       NsLdapSchemaType = "AD"
+)
+
+var pNsLdapSchemaTypeOpenldap NsLdapSchemaType
+var pNsLdapSchemaTypeAd NsLdapSchemaType
+
+// NsLdapSchemaTypeOpenldap enum exports
+var NsLdapSchemaTypeOpenldap *NsLdapSchemaType
+
+// NsLdapSchemaTypeAd enum exports
+var NsLdapSchemaTypeAd *NsLdapSchemaType
+
+func init() {
+	pNsLdapSchemaTypeOpenldap = cNsLdapSchemaTypeOpenldap
+	NsLdapSchemaTypeOpenldap = &pNsLdapSchemaTypeOpenldap
+
+	pNsLdapSchemaTypeAd = cNsLdapSchemaTypeAd
+	NsLdapSchemaTypeAd = &pNsLdapSchemaTypeAd
+
+}

--- a/pkg/client/v1/nimbleos/ns_ldap_user.go
+++ b/pkg/client/v1/nimbleos/ns_ldap_user.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package nimbleos
+
+// NsLdapUser - Information about the current status of an LDAP user.
+// Export NsLdapUserFields for advance operations like search filter etc.
+var NsLdapUserFields *NsLdapUser
+
+func init() {
+	Userfield := "user"
+	PrimaryGroupNamefield := "primary_group_name"
+	PrimaryGroupIdfield := "primary_group_id"
+
+	NsLdapUserFields = &NsLdapUser{
+		User:             &Userfield,
+		PrimaryGroupName: &PrimaryGroupNamefield,
+		PrimaryGroupId:   &PrimaryGroupIdfield,
+	}
+}
+
+type NsLdapUser struct {
+	// User - The user's username.
+	User *string `json:"user,omitempty"`
+	// PrimaryGroupName - The name of the configured LDAP group used to determine the user's role.
+	PrimaryGroupName *string `json:"primary_group_name,omitempty"`
+	// PrimaryGroupId - The external identifier for the configured LDAP group uset to determine the user's role.
+	PrimaryGroupId *string `json:"primary_group_id,omitempty"`
+	// GroupCount - How many configured LDAP groups is the user is currently reported as having membership in.
+	GroupCount *int64 `json:"group_count,omitempty"`
+	// Groups - A list of all the configured LDAP groups the user is currently reported to have membership in.
+	Groups []*string `json:"groups,omitempty"`
+	// Role - The role currently available to the user.
+	Role *NsUserRoles `json:"role,omitempty"`
+}

--- a/pkg/client/v1/nimbleos/ns_plat_link_speed.go
+++ b/pkg/client/v1/nimbleos/ns_plat_link_speed.go
@@ -6,24 +6,34 @@ package nimbleos
 type NsPlatLinkSpeed string
 
 const (
+	cNsPlatLinkSpeedLinkSpeed100000m NsPlatLinkSpeed = "link_speed_100000M"
 	cNsPlatLinkSpeedLinkSpeed10000m  NsPlatLinkSpeed = "link_speed_10000M"
 	cNsPlatLinkSpeedLinkSpeed10m     NsPlatLinkSpeed = "link_speed_10M"
+	cNsPlatLinkSpeedLinkSpeed25000m  NsPlatLinkSpeed = "link_speed_25000M"
 	cNsPlatLinkSpeedLinkSpeedUnknown NsPlatLinkSpeed = "link_speed_unknown"
 	cNsPlatLinkSpeedLinkSpeed1000m   NsPlatLinkSpeed = "link_speed_1000M"
 	cNsPlatLinkSpeedLinkSpeed100m    NsPlatLinkSpeed = "link_speed_100M"
 )
 
+var pNsPlatLinkSpeedLinkSpeed100000m NsPlatLinkSpeed
 var pNsPlatLinkSpeedLinkSpeed10000m NsPlatLinkSpeed
 var pNsPlatLinkSpeedLinkSpeed10m NsPlatLinkSpeed
+var pNsPlatLinkSpeedLinkSpeed25000m NsPlatLinkSpeed
 var pNsPlatLinkSpeedLinkSpeedUnknown NsPlatLinkSpeed
 var pNsPlatLinkSpeedLinkSpeed1000m NsPlatLinkSpeed
 var pNsPlatLinkSpeedLinkSpeed100m NsPlatLinkSpeed
+
+// NsPlatLinkSpeedLinkSpeed100000m enum exports
+var NsPlatLinkSpeedLinkSpeed100000m *NsPlatLinkSpeed
 
 // NsPlatLinkSpeedLinkSpeed10000m enum exports
 var NsPlatLinkSpeedLinkSpeed10000m *NsPlatLinkSpeed
 
 // NsPlatLinkSpeedLinkSpeed10m enum exports
 var NsPlatLinkSpeedLinkSpeed10m *NsPlatLinkSpeed
+
+// NsPlatLinkSpeedLinkSpeed25000m enum exports
+var NsPlatLinkSpeedLinkSpeed25000m *NsPlatLinkSpeed
 
 // NsPlatLinkSpeedLinkSpeedUnknown enum exports
 var NsPlatLinkSpeedLinkSpeedUnknown *NsPlatLinkSpeed
@@ -35,11 +45,17 @@ var NsPlatLinkSpeedLinkSpeed1000m *NsPlatLinkSpeed
 var NsPlatLinkSpeedLinkSpeed100m *NsPlatLinkSpeed
 
 func init() {
+	pNsPlatLinkSpeedLinkSpeed100000m = cNsPlatLinkSpeedLinkSpeed100000m
+	NsPlatLinkSpeedLinkSpeed100000m = &pNsPlatLinkSpeedLinkSpeed100000m
+
 	pNsPlatLinkSpeedLinkSpeed10000m = cNsPlatLinkSpeedLinkSpeed10000m
 	NsPlatLinkSpeedLinkSpeed10000m = &pNsPlatLinkSpeedLinkSpeed10000m
 
 	pNsPlatLinkSpeedLinkSpeed10m = cNsPlatLinkSpeedLinkSpeed10m
 	NsPlatLinkSpeedLinkSpeed10m = &pNsPlatLinkSpeedLinkSpeed10m
+
+	pNsPlatLinkSpeedLinkSpeed25000m = cNsPlatLinkSpeedLinkSpeed25000m
+	NsPlatLinkSpeedLinkSpeed25000m = &pNsPlatLinkSpeedLinkSpeed25000m
 
 	pNsPlatLinkSpeedLinkSpeedUnknown = cNsPlatLinkSpeedLinkSpeedUnknown
 	NsPlatLinkSpeedLinkSpeedUnknown = &pNsPlatLinkSpeedLinkSpeedUnknown

--- a/pkg/client/v1/nimbleos/ns_token_report_user_details_return.go
+++ b/pkg/client/v1/nimbleos/ns_token_report_user_details_return.go
@@ -23,11 +23,11 @@ func init() {
 type NsTokenReportUserDetailsReturn struct {
 	// UserName - User name for the session.
 	UserName *string `json:"user_name,omitempty"`
-	// PrimaryGroupId - The ID of the primary Active Directory user group the user belongs to. RBAC is granted based on this group.
+	// PrimaryGroupId - The ID of the primary directory service user group the user belongs to. RBAC is granted based on this group.
 	PrimaryGroupId *string `json:"primary_group_id,omitempty"`
-	// PrimaryGroupName - The primary Active Directory user group the user belongs to. RBAC is granted based on this group.
+	// PrimaryGroupName - The primary directory user group the user belongs to. RBAC is granted based on this group.
 	PrimaryGroupName *string `json:"primary_group_name,omitempty"`
-	// GroupCount - The number of Active Directory user groups the user belongs to.
+	// GroupCount - The number of directory service user groups the user belongs to.
 	GroupCount *int64 `json:"group_count,omitempty"`
 	// Role - Role of the user.
 	Role *NsUserRoles `json:"role,omitempty"`
@@ -35,6 +35,8 @@ type NsTokenReportUserDetailsReturn struct {
 	InactivityTimeout *int64 `json:"inactivity_timeout,omitempty"`
 	// UserId - Global ID of the user.
 	UserId *string `json:"user_id,omitempty"`
-	// Groups - The list of Active Directory groups the user belongs to.
+	// DomainType - Connected directory service type. Either 'ad, 'ldap' or 'local'.
+	DomainType *NsDomainType `json:"domain_type,omitempty"`
+	// Groups - The list of directory service groups the user belongs to.
 	Groups []*string `json:"groups,omitempty"`
 }

--- a/pkg/client/v1/nimbleos/protection_schedule.go
+++ b/pkg/client/v1/nimbleos/protection_schedule.go
@@ -21,22 +21,24 @@ func init() {
 	LastReplicatedSnapcollIdfield := "last_replicated_snapcoll_id"
 	SchedOwnerIdfield := "sched_owner_id"
 	SchedOwnerNamefield := "sched_owner_name"
+	CurrentlyReplicatingSnapcollNamefield := "currently_replicating_snapcoll_name"
 
 	ProtectionScheduleFields = &ProtectionSchedule{
-		ID:                         &IDfield,
-		Name:                       &Namefield,
-		Description:                &Descriptionfield,
-		VolcollOrProttmplId:        &VolcollOrProttmplIdfield,
-		Days:                       &Daysfield,
-		DownstreamPartner:          &DownstreamPartnerfield,
-		DownstreamPartnerName:      &DownstreamPartnerNamefield,
-		DownstreamPartnerId:        &DownstreamPartnerIdfield,
-		UpstreamPartnerName:        &UpstreamPartnerNamefield,
-		UpstreamPartnerId:          &UpstreamPartnerIdfield,
-		LastReplicatedSnapcollName: &LastReplicatedSnapcollNamefield,
-		LastReplicatedSnapcollId:   &LastReplicatedSnapcollIdfield,
-		SchedOwnerId:               &SchedOwnerIdfield,
-		SchedOwnerName:             &SchedOwnerNamefield,
+		ID:                               &IDfield,
+		Name:                             &Namefield,
+		Description:                      &Descriptionfield,
+		VolcollOrProttmplId:              &VolcollOrProttmplIdfield,
+		Days:                             &Daysfield,
+		DownstreamPartner:                &DownstreamPartnerfield,
+		DownstreamPartnerName:            &DownstreamPartnerNamefield,
+		DownstreamPartnerId:              &DownstreamPartnerIdfield,
+		UpstreamPartnerName:              &UpstreamPartnerNamefield,
+		UpstreamPartnerId:                &UpstreamPartnerIdfield,
+		LastReplicatedSnapcollName:       &LastReplicatedSnapcollNamefield,
+		LastReplicatedSnapcollId:         &LastReplicatedSnapcollIdfield,
+		SchedOwnerId:                     &SchedOwnerIdfield,
+		SchedOwnerName:                   &SchedOwnerNamefield,
+		CurrentlyReplicatingSnapcollName: &CurrentlyReplicatingSnapcollNamefield,
 	}
 }
 
@@ -115,6 +117,8 @@ type ProtectionSchedule struct {
 	SchedOwnerName *string `json:"sched_owner_name,omitempty"`
 	// LastConfigChangeTime - The last timing configutation changed.
 	LastConfigChangeTime *int64 `json:"last_config_change_time,omitempty"`
+	// CurrentlyReplicatingSnapcollName - The name of the currently replicating snapshot collection if one exists, the empty string otherwise.
+	CurrentlyReplicatingSnapcollName *string `json:"currently_replicating_snapcoll_name,omitempty"`
 	// VolStatusList - The list of the replication status of volumes undergoing replication.
 	VolStatusList []*NsReplVolStatus `json:"vol_status_list,omitempty"`
 	// SyncReplVolStatusList - A list of the replication status of volumes undergoing synchronous replication.

--- a/pkg/client/v1/nimbleos/snapshot_collection.go
+++ b/pkg/client/v1/nimbleos/snapshot_collection.go
@@ -57,6 +57,8 @@ type SnapshotCollection struct {
 	SrepOwnerId *string `json:"srep_owner_id,omitempty"`
 	// PeerSnapcollId - ID of the peer snapshot collection created by synchronous replication. Field will be null if no peer snapshot_collection was created by synchronous replication.
 	PeerSnapcollId *string `json:"peer_snapcoll_id,omitempty"`
+	// NumSnaps - Current number of live, non-hidden snaps in this collection.
+	NumSnaps *int64 `json:"num_snaps,omitempty"`
 	// IsComplete - Is complete.
 	IsComplete *bool `json:"is_complete,omitempty"`
 	// IsManual - Is manual.

--- a/pkg/service/access_control_record_service.go
+++ b/pkg/service/access_control_record_service.go
@@ -24,10 +24,6 @@ func NewAccessControlRecordService(gs *NsGroupService) *AccessControlRecordServi
 
 // GetAccessControlRecords - method returns a array of pointers of type "AccessControlRecords"
 func (svc *AccessControlRecordService) GetAccessControlRecords(params *param.GetParams) ([]*nimbleos.AccessControlRecord, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetAccessControlRecords: invalid parameter specified, %v", params)
-	}
-
 	accessControlRecordResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/active_directory_membership_service.go
+++ b/pkg/service/active_directory_membership_service.go
@@ -24,10 +24,6 @@ func NewActiveDirectoryMembershipService(gs *NsGroupService) *ActiveDirectoryMem
 
 // GetActiveDirectoryMemberships - method returns a array of pointers of type "ActiveDirectoryMemberships"
 func (svc *ActiveDirectoryMembershipService) GetActiveDirectoryMemberships(params *param.GetParams) ([]*nimbleos.ActiveDirectoryMembership, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetActiveDirectoryMemberships: invalid parameter specified, %v", params)
-	}
-
 	activeDirectoryMembershipResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/alarm_service.go
+++ b/pkg/service/alarm_service.go
@@ -24,10 +24,6 @@ func NewAlarmService(gs *NsGroupService) *AlarmService {
 
 // GetAlarms - method returns a array of pointers of type "Alarms"
 func (svc *AlarmService) GetAlarms(params *param.GetParams) ([]*nimbleos.Alarm, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetAlarms: invalid parameter specified, %v", params)
-	}
-
 	alarmResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/application_category_service.go
+++ b/pkg/service/application_category_service.go
@@ -24,10 +24,6 @@ func NewApplicationCategoryService(gs *NsGroupService) *ApplicationCategoryServi
 
 // GetApplicationCategories - method returns a array of pointers of type "ApplicationCategories"
 func (svc *ApplicationCategoryService) GetApplicationCategories(params *param.GetParams) ([]*nimbleos.ApplicationCategory, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetApplicationCategories: invalid parameter specified, %v", params)
-	}
-
 	applicationCategoryResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/application_server_service.go
+++ b/pkg/service/application_server_service.go
@@ -24,10 +24,6 @@ func NewApplicationServerService(gs *NsGroupService) *ApplicationServerService {
 
 // GetApplicationServers - method returns a array of pointers of type "ApplicationServers"
 func (svc *ApplicationServerService) GetApplicationServers(params *param.GetParams) ([]*nimbleos.ApplicationServer, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetApplicationServers: invalid parameter specified, %v", params)
-	}
-
 	applicationServerResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/array_service.go
+++ b/pkg/service/array_service.go
@@ -24,10 +24,6 @@ func NewArrayService(gs *NsGroupService) *ArrayService {
 
 // GetArrays - method returns a array of pointers of type "Arrays"
 func (svc *ArrayService) GetArrays(params *param.GetParams) ([]*nimbleos.Array, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetArrays: invalid parameter specified, %v", params)
-	}
-
 	arrayResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/audit_log_service.go
+++ b/pkg/service/audit_log_service.go
@@ -24,10 +24,6 @@ func NewAuditLogService(gs *NsGroupService) *AuditLogService {
 
 // GetAuditLogs - method returns a array of pointers of type "AuditLogs"
 func (svc *AuditLogService) GetAuditLogs(params *param.GetParams) ([]*nimbleos.AuditLog, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetAuditLogs: invalid parameter specified, %v", params)
-	}
-
 	auditLogResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/chap_user_service.go
+++ b/pkg/service/chap_user_service.go
@@ -26,10 +26,6 @@ func NewChapUserService(gs *NsGroupService) *ChapUserService {
 
 // GetChapUsers - method returns a array of pointers of type "ChapUsers"
 func (svc *ChapUserService) GetChapUsers(params *param.GetParams) ([]*nimbleos.ChapUser, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetChapUsers: invalid parameter specified, %v", params)
-	}
-
 	chapUserResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/controller_service.go
+++ b/pkg/service/controller_service.go
@@ -24,10 +24,6 @@ func NewControllerService(gs *NsGroupService) *ControllerService {
 
 // GetControllers - method returns a array of pointers of type "Controllers"
 func (svc *ControllerService) GetControllers(params *param.GetParams) ([]*nimbleos.Controller, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetControllers: invalid parameter specified, %v", params)
-	}
-
 	controllerResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/disk_service.go
+++ b/pkg/service/disk_service.go
@@ -24,10 +24,6 @@ func NewDiskService(gs *NsGroupService) *DiskService {
 
 // GetDisks - method returns a array of pointers of type "Disks"
 func (svc *DiskService) GetDisks(params *param.GetParams) ([]*nimbleos.Disk, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetDisks: invalid parameter specified, %v", params)
-	}
-
 	diskResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/event_service.go
+++ b/pkg/service/event_service.go
@@ -24,10 +24,6 @@ func NewEventService(gs *NsGroupService) *EventService {
 
 // GetEvents - method returns a array of pointers of type "Events"
 func (svc *EventService) GetEvents(params *param.GetParams) ([]*nimbleos.Event, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetEvents: invalid parameter specified, %v", params)
-	}
-
 	eventResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/fibre_channel_config_service.go
+++ b/pkg/service/fibre_channel_config_service.go
@@ -24,10 +24,6 @@ func NewFibreChannelConfigService(gs *NsGroupService) *FibreChannelConfigService
 
 // GetFibreChannelConfigs - method returns a array of pointers of type "FibreChannelConfigs"
 func (svc *FibreChannelConfigService) GetFibreChannelConfigs(params *param.GetParams) ([]*nimbleos.FibreChannelConfig, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFibreChannelConfigs: invalid parameter specified, %v", params)
-	}
-
 	fibreChannelConfigResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/fibre_channel_initiator_alias_service.go
+++ b/pkg/service/fibre_channel_initiator_alias_service.go
@@ -24,10 +24,6 @@ func NewFibreChannelInitiatorAliasService(gs *NsGroupService) *FibreChannelIniti
 
 // GetFibreChannelInitiatorAliass - method returns a array of pointers of type "FibreChannelInitiatorAliass"
 func (svc *FibreChannelInitiatorAliasService) GetFibreChannelInitiatorAliass(params *param.GetParams) ([]*nimbleos.FibreChannelInitiatorAlias, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFibreChannelInitiatorAliass: invalid parameter specified, %v", params)
-	}
-
 	fibreChannelInitiatorAliasResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/fibre_channel_interface_service.go
+++ b/pkg/service/fibre_channel_interface_service.go
@@ -24,10 +24,6 @@ func NewFibreChannelInterfaceService(gs *NsGroupService) *FibreChannelInterfaceS
 
 // GetFibreChannelInterfaces - method returns a array of pointers of type "FibreChannelInterfaces"
 func (svc *FibreChannelInterfaceService) GetFibreChannelInterfaces(params *param.GetParams) ([]*nimbleos.FibreChannelInterface, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFibreChannelInterfaces: invalid parameter specified, %v", params)
-	}
-
 	fibreChannelInterfaceResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/fibre_channel_port_service.go
+++ b/pkg/service/fibre_channel_port_service.go
@@ -24,10 +24,6 @@ func NewFibreChannelPortService(gs *NsGroupService) *FibreChannelPortService {
 
 // GetFibreChannelPorts - method returns a array of pointers of type "FibreChannelPorts"
 func (svc *FibreChannelPortService) GetFibreChannelPorts(params *param.GetParams) ([]*nimbleos.FibreChannelPort, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFibreChannelPorts: invalid parameter specified, %v", params)
-	}
-
 	fibreChannelPortResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/fibre_channel_session_service.go
+++ b/pkg/service/fibre_channel_session_service.go
@@ -24,10 +24,6 @@ func NewFibreChannelSessionService(gs *NsGroupService) *FibreChannelSessionServi
 
 // GetFibreChannelSessions - method returns a array of pointers of type "FibreChannelSessions"
 func (svc *FibreChannelSessionService) GetFibreChannelSessions(params *param.GetParams) ([]*nimbleos.FibreChannelSession, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFibreChannelSessions: invalid parameter specified, %v", params)
-	}
-
 	fibreChannelSessionResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/folder_service.go
+++ b/pkg/service/folder_service.go
@@ -24,10 +24,6 @@ func NewFolderService(gs *NsGroupService) *FolderService {
 
 // GetFolders - method returns a array of pointers of type "Folders"
 func (svc *FolderService) GetFolders(params *param.GetParams) ([]*nimbleos.Folder, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetFolders: invalid parameter specified, %v", params)
-	}
-
 	folderResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/group_service.go
+++ b/pkg/service/group_service.go
@@ -24,10 +24,6 @@ func NewGroupService(gs *NsGroupService) *GroupService {
 
 // GetGroups - method returns a array of pointers of type "Groups"
 func (svc *GroupService) GetGroups(params *param.GetParams) ([]*nimbleos.Group, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetGroups: invalid parameter specified, %v", params)
-	}
-
 	groupResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/group_service_factory.go
+++ b/pkg/service/group_service_factory.go
@@ -20,6 +20,7 @@ type NsGroupService struct {
 	chapUserService                   *ChapUserService
 	masterKeyService                  *MasterKeyService
 	alarmService                      *AlarmService
+	subscriptionService               *SubscriptionService
 	volumeService                     *VolumeService
 	shelfService                      *ShelfService
 	keyManagerService                 *KeyManagerService
@@ -55,10 +56,12 @@ type NsGroupService struct {
 	auditLogService                   *AuditLogService
 	poolService                       *PoolService
 	volumeCollectionService           *VolumeCollectionService
+	subscriberService                 *SubscriberService
 	diskService                       *DiskService
 	fibreChannelInitiatorAliasService *FibreChannelInitiatorAliasService
 	groupService                      *GroupService
 	softwareVersionService            *SoftwareVersionService
+	ldapDomainService                 *LdapDomainService
 	networkConfigService              *NetworkConfigService
 }
 
@@ -74,7 +77,7 @@ func NewNsGroupService(ip, username, password, apiVersion string, synchronous bo
 	return &NsGroupService{ip: ip, client: client}, nil
 }
 
-// LogoutService - delete session token
+// LogoutService - delete the session token
 func (gs *NsGroupService) LogoutService() error {
 	tokenService := gs.GetTokenService()
 	sessionToken := gs.client.SessionToken
@@ -137,6 +140,14 @@ func (gs *NsGroupService) GetAlarmService() (vs *AlarmService) {
 		gs.alarmService = NewAlarmService(gs)
 	}
 	return gs.alarmService
+}
+
+// GetSubscriptionService - returns service of a type *SubscriptionService
+func (gs *NsGroupService) GetSubscriptionService() (vs *SubscriptionService) {
+	if gs.subscriptionService == nil {
+		gs.subscriptionService = NewSubscriptionService(gs)
+	}
+	return gs.subscriptionService
 }
 
 // GetVolumeService - returns service of a type *VolumeService
@@ -419,6 +430,14 @@ func (gs *NsGroupService) GetVolumeCollectionService() (vs *VolumeCollectionServ
 	return gs.volumeCollectionService
 }
 
+// GetSubscriberService - returns service of a type *SubscriberService
+func (gs *NsGroupService) GetSubscriberService() (vs *SubscriberService) {
+	if gs.subscriberService == nil {
+		gs.subscriberService = NewSubscriberService(gs)
+	}
+	return gs.subscriberService
+}
+
 // GetDiskService - returns service of a type *DiskService
 func (gs *NsGroupService) GetDiskService() (vs *DiskService) {
 	if gs.diskService == nil {
@@ -449,6 +468,14 @@ func (gs *NsGroupService) GetSoftwareVersionService() (vs *SoftwareVersionServic
 		gs.softwareVersionService = NewSoftwareVersionService(gs)
 	}
 	return gs.softwareVersionService
+}
+
+// GetLdapDomainService - returns service of a type *LdapDomainService
+func (gs *NsGroupService) GetLdapDomainService() (vs *LdapDomainService) {
+	if gs.ldapDomainService == nil {
+		gs.ldapDomainService = NewLdapDomainService(gs)
+	}
+	return gs.ldapDomainService
 }
 
 // GetNetworkConfigService - returns service of a type *NetworkConfigService

--- a/pkg/service/initiator_group_service.go
+++ b/pkg/service/initiator_group_service.go
@@ -25,10 +25,6 @@ func NewInitiatorGroupService(gs *NsGroupService) *InitiatorGroupService {
 
 // GetInitiatorGroups - method returns a array of pointers of type "InitiatorGroups"
 func (svc *InitiatorGroupService) GetInitiatorGroups(params *param.GetParams) ([]*nimbleos.InitiatorGroup, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetInitiatorGroups: invalid parameter specified, %v", params)
-	}
-
 	initiatorGroupResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/initiator_service.go
+++ b/pkg/service/initiator_service.go
@@ -24,10 +24,6 @@ func NewInitiatorService(gs *NsGroupService) *InitiatorService {
 
 // GetInitiators - method returns a array of pointers of type "Initiators"
 func (svc *InitiatorService) GetInitiators(params *param.GetParams) ([]*nimbleos.Initiator, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetInitiators: invalid parameter specified, %v", params)
-	}
-
 	initiatorResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/job_service.go
+++ b/pkg/service/job_service.go
@@ -24,10 +24,6 @@ func NewJobService(gs *NsGroupService) *JobService {
 
 // GetJobs - method returns a array of pointers of type "Jobs"
 func (svc *JobService) GetJobs(params *param.GetParams) ([]*nimbleos.Job, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetJobs: invalid parameter specified, %v", params)
-	}
-
 	jobResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/key_manager_service.go
+++ b/pkg/service/key_manager_service.go
@@ -24,10 +24,6 @@ func NewKeyManagerService(gs *NsGroupService) *KeyManagerService {
 
 // GetKeyManagers - method returns a array of pointers of type "KeyManagers"
 func (svc *KeyManagerService) GetKeyManagers(params *param.GetParams) ([]*nimbleos.KeyManager, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetKeyManagers: invalid parameter specified, %v", params)
-	}
-
 	keyManagerResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/ldap_domain_service.go
+++ b/pkg/service/ldap_domain_service.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// LdapDomain Service - Manages the storage array's membership with LDAP servers.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// LdapDomainService type
+type LdapDomainService struct {
+	objectSet *client.LdapDomainObjectSet
+}
+
+// NewLdapDomainService - method to initialize "LdapDomainService"
+func NewLdapDomainService(gs *NsGroupService) *LdapDomainService {
+	objectSet := gs.client.GetLdapDomainObjectSet()
+	return &LdapDomainService{objectSet: objectSet}
+}
+
+// GetLdapDomains - method returns a array of pointers of type "LdapDomains"
+func (svc *LdapDomainService) GetLdapDomains(params *param.GetParams) ([]*nimbleos.LdapDomain, error) {
+	ldapDomainResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// CreateLdapDomain - method creates a "LdapDomain"
+func (svc *LdapDomainService) CreateLdapDomain(obj *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateLdapDomain: invalid parameter specified, %v", obj)
+	}
+
+	ldapDomainResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// UpdateLdapDomain - method modifies  the "LdapDomain"
+func (svc *LdapDomainService) UpdateLdapDomain(id string, obj *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateLdapDomain: invalid parameter specified, %v", obj)
+	}
+
+	ldapDomainResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// GetLdapDomainById - method returns a pointer to "LdapDomain"
+func (svc *LdapDomainService) GetLdapDomainById(id string) (*nimbleos.LdapDomain, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetLdapDomainById: invalid parameter specified, %v", id)
+	}
+
+	ldapDomainResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// DeleteLdapDomain - deletes the "LdapDomain"
+func (svc *LdapDomainService) DeleteLdapDomain(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteLdapDomain: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TestUserLdapDomain - tests whether the user exist in the given LDAP Domain.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+//       user - Name of the LDAP Domain user.
+
+func (svc *LdapDomainService) TestUserLdapDomain(id string, user string) (*nimbleos.NsLdapUser, error) {
+
+	if len(id) == 0 || len(user) == 0 {
+		return nil, fmt.Errorf("TestUserLdapDomain: invalid parameter specified id: %v, user: %v ", id, user)
+	}
+
+	resp, err := svc.objectSet.TestUser(&id, &user)
+	return resp, err
+}
+
+// TestGroupLdapDomain - tests whether the user group exist in the given LDAP Domain.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+//       group - Name of the group.
+
+func (svc *LdapDomainService) TestGroupLdapDomain(id string, group string) error {
+
+	if len(id) == 0 || len(group) == 0 {
+		return fmt.Errorf("TestGroupLdapDomain: invalid parameter specified id: %v, group: %v ", id, group)
+	}
+
+	err := svc.objectSet.TestGroup(&id, &group)
+	return err
+}
+
+// ReportStatusLdapDomain - reports the LDAP connectivity status of the given LDAP ID.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+
+func (svc *LdapDomainService) ReportStatusLdapDomain(id string) (*nimbleos.NsLdapReportStatusReturn, error) {
+
+	if len(id) == 0 {
+		return nil, fmt.Errorf("ReportStatusLdapDomain: invalid parameter specified id: %v ", id)
+	}
+
+	resp, err := svc.objectSet.ReportStatus(&id)
+	return resp, err
+}

--- a/pkg/service/master_key_service.go
+++ b/pkg/service/master_key_service.go
@@ -26,10 +26,6 @@ func NewMasterKeyService(gs *NsGroupService) *MasterKeyService {
 
 // GetMasterKeys - method returns a array of pointers of type "MasterKeys"
 func (svc *MasterKeyService) GetMasterKeys(params *param.GetParams) ([]*nimbleos.MasterKey, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetMasterKeys: invalid parameter specified, %v", params)
-	}
-
 	masterKeyResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/network_config_service.go
+++ b/pkg/service/network_config_service.go
@@ -24,10 +24,6 @@ func NewNetworkConfigService(gs *NsGroupService) *NetworkConfigService {
 
 // GetNetworkConfigs - method returns a array of pointers of type "NetworkConfigs"
 func (svc *NetworkConfigService) GetNetworkConfigs(params *param.GetParams) ([]*nimbleos.NetworkConfig, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetNetworkConfigs: invalid parameter specified, %v", params)
-	}
-
 	networkConfigResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/network_interface_service.go
+++ b/pkg/service/network_interface_service.go
@@ -24,10 +24,6 @@ func NewNetworkInterfaceService(gs *NsGroupService) *NetworkInterfaceService {
 
 // GetNetworkInterfaces - method returns a array of pointers of type "NetworkInterfaces"
 func (svc *NetworkInterfaceService) GetNetworkInterfaces(params *param.GetParams) ([]*nimbleos.NetworkInterface, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetNetworkInterfaces: invalid parameter specified, %v", params)
-	}
-
 	networkInterfaceResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/performance_policy_service.go
+++ b/pkg/service/performance_policy_service.go
@@ -26,10 +26,6 @@ func NewPerformancePolicyService(gs *NsGroupService) *PerformancePolicyService {
 
 // GetPerformancePolicies - method returns a array of pointers of type "PerformancePolicies"
 func (svc *PerformancePolicyService) GetPerformancePolicies(params *param.GetParams) ([]*nimbleos.PerformancePolicy, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetPerformancePolicies: invalid parameter specified, %v", params)
-	}
-
 	performancePolicyResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/pool_service.go
+++ b/pkg/service/pool_service.go
@@ -24,10 +24,6 @@ func NewPoolService(gs *NsGroupService) *PoolService {
 
 // GetPools - method returns a array of pointers of type "Pools"
 func (svc *PoolService) GetPools(params *param.GetParams) ([]*nimbleos.Pool, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetPools: invalid parameter specified, %v", params)
-	}
-
 	poolResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/protection_schedule_service.go
+++ b/pkg/service/protection_schedule_service.go
@@ -24,10 +24,6 @@ func NewProtectionScheduleService(gs *NsGroupService) *ProtectionScheduleService
 
 // GetProtectionSchedules - method returns a array of pointers of type "ProtectionSchedules"
 func (svc *ProtectionScheduleService) GetProtectionSchedules(params *param.GetParams) ([]*nimbleos.ProtectionSchedule, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetProtectionSchedules: invalid parameter specified, %v", params)
-	}
-
 	protectionScheduleResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/protection_template_service.go
+++ b/pkg/service/protection_template_service.go
@@ -27,10 +27,6 @@ func NewProtectionTemplateService(gs *NsGroupService) *ProtectionTemplateService
 
 // GetProtectionTemplates - method returns a array of pointers of type "ProtectionTemplates"
 func (svc *ProtectionTemplateService) GetProtectionTemplates(params *param.GetParams) ([]*nimbleos.ProtectionTemplate, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetProtectionTemplates: invalid parameter specified, %v", params)
-	}
-
 	protectionTemplateResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/protocol_endpoint_service.go
+++ b/pkg/service/protocol_endpoint_service.go
@@ -24,10 +24,6 @@ func NewProtocolEndpointService(gs *NsGroupService) *ProtocolEndpointService {
 
 // GetProtocolEndpoints - method returns a array of pointers of type "ProtocolEndpoints"
 func (svc *ProtocolEndpointService) GetProtocolEndpoints(params *param.GetParams) ([]*nimbleos.ProtocolEndpoint, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetProtocolEndpoints: invalid parameter specified, %v", params)
-	}
-
 	protocolEndpointResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/replication_partner_service.go
+++ b/pkg/service/replication_partner_service.go
@@ -26,10 +26,6 @@ func NewReplicationPartnerService(gs *NsGroupService) *ReplicationPartnerService
 
 // GetReplicationPartners - method returns a array of pointers of type "ReplicationPartners"
 func (svc *ReplicationPartnerService) GetReplicationPartners(params *param.GetParams) ([]*nimbleos.ReplicationPartner, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetReplicationPartners: invalid parameter specified, %v", params)
-	}
-
 	replicationPartnerResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/shelf_service.go
+++ b/pkg/service/shelf_service.go
@@ -24,10 +24,6 @@ func NewShelfService(gs *NsGroupService) *ShelfService {
 
 // GetShelfs - method returns a array of pointers of type "Shelfs"
 func (svc *ShelfService) GetShelfs(params *param.GetParams) ([]*nimbleos.Shelf, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetShelfs: invalid parameter specified, %v", params)
-	}
-
 	shelfResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/snapshot_collection_service.go
+++ b/pkg/service/snapshot_collection_service.go
@@ -25,10 +25,6 @@ func NewSnapshotCollectionService(gs *NsGroupService) *SnapshotCollectionService
 
 // GetSnapshotCollections - method returns a array of pointers of type "SnapshotCollections"
 func (svc *SnapshotCollectionService) GetSnapshotCollections(params *param.GetParams) ([]*nimbleos.SnapshotCollection, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetSnapshotCollections: invalid parameter specified, %v", params)
-	}
-
 	snapshotCollectionResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/snapshot_service.go
+++ b/pkg/service/snapshot_service.go
@@ -26,10 +26,6 @@ func NewSnapshotService(gs *NsGroupService) *SnapshotService {
 
 // GetSnapshots - method returns a array of pointers of type "Snapshots"
 func (svc *SnapshotService) GetSnapshots(params *param.GetParams) ([]*nimbleos.Snapshot, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetSnapshots: invalid parameter specified, %v", params)
-	}
-
 	snapshotResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/software_version_service.go
+++ b/pkg/service/software_version_service.go
@@ -24,10 +24,6 @@ func NewSoftwareVersionService(gs *NsGroupService) *SoftwareVersionService {
 
 // GetSoftwareVersions - method returns a array of pointers of type "SoftwareVersions"
 func (svc *SoftwareVersionService) GetSoftwareVersions(params *param.GetParams) ([]*nimbleos.SoftwareVersion, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetSoftwareVersions: invalid parameter specified, %v", params)
-	}
-
 	softwareVersionResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/space_domain_service.go
+++ b/pkg/service/space_domain_service.go
@@ -24,10 +24,6 @@ func NewSpaceDomainService(gs *NsGroupService) *SpaceDomainService {
 
 // GetSpaceDomains - method returns a array of pointers of type "SpaceDomains"
 func (svc *SpaceDomainService) GetSpaceDomains(params *param.GetParams) ([]*nimbleos.SpaceDomain, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetSpaceDomains: invalid parameter specified, %v", params)
-	}
-
 	spaceDomainResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/subnet_service.go
+++ b/pkg/service/subnet_service.go
@@ -25,10 +25,6 @@ func NewSubnetService(gs *NsGroupService) *SubnetService {
 
 // GetSubnets - method returns a array of pointers of type "Subnets"
 func (svc *SubnetService) GetSubnets(params *param.GetParams) ([]*nimbleos.Subnet, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetSubnets: invalid parameter specified, %v", params)
-	}
-
 	subnetResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/subscriber_service.go
+++ b/pkg/service/subscriber_service.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// Subscriber Service - Subscribers are websocket based notification clients that can subscribe to interesting operations and events and recieve notifications whenever the subscribed to operations and
+// events happen on the array.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// SubscriberService type
+type SubscriberService struct {
+	objectSet *client.SubscriberObjectSet
+}
+
+// NewSubscriberService - method to initialize "SubscriberService"
+func NewSubscriberService(gs *NsGroupService) *SubscriberService {
+	objectSet := gs.client.GetSubscriberObjectSet()
+	return &SubscriberService{objectSet: objectSet}
+}
+
+// GetSubscribers - method returns a array of pointers of type "Subscribers"
+func (svc *SubscriberService) GetSubscribers(params *param.GetParams) ([]*nimbleos.Subscriber, error) {
+	subscriberResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// CreateSubscriber - method creates a "Subscriber"
+func (svc *SubscriberService) CreateSubscriber(obj *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateSubscriber: invalid parameter specified, %v", obj)
+	}
+
+	subscriberResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// UpdateSubscriber - method modifies  the "Subscriber"
+func (svc *SubscriberService) UpdateSubscriber(id string, obj *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateSubscriber: invalid parameter specified, %v", obj)
+	}
+
+	subscriberResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// GetSubscriberById - method returns a pointer to "Subscriber"
+func (svc *SubscriberService) GetSubscriberById(id string) (*nimbleos.Subscriber, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetSubscriberById: invalid parameter specified, %v", id)
+	}
+
+	subscriberResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// DeleteSubscriber - deletes the "Subscriber"
+func (svc *SubscriberService) DeleteSubscriber(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteSubscriber: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/service/subscription_service.go
+++ b/pkg/service/subscription_service.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// Subscription Service - Subscriptions represent the list of object types or alerts that a websocket client is interested in getting notifications for. Each subscription belongs to a single notification
+// client.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// SubscriptionService type
+type SubscriptionService struct {
+	objectSet *client.SubscriptionObjectSet
+}
+
+// NewSubscriptionService - method to initialize "SubscriptionService"
+func NewSubscriptionService(gs *NsGroupService) *SubscriptionService {
+	objectSet := gs.client.GetSubscriptionObjectSet()
+	return &SubscriptionService{objectSet: objectSet}
+}
+
+// GetSubscriptions - method returns a array of pointers of type "Subscriptions"
+func (svc *SubscriptionService) GetSubscriptions(params *param.GetParams) ([]*nimbleos.Subscription, error) {
+	subscriptionResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// CreateSubscription - method creates a "Subscription"
+func (svc *SubscriptionService) CreateSubscription(obj *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateSubscription: invalid parameter specified, %v", obj)
+	}
+
+	subscriptionResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// UpdateSubscription - method modifies  the "Subscription"
+func (svc *SubscriptionService) UpdateSubscription(id string, obj *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateSubscription: invalid parameter specified, %v", obj)
+	}
+
+	subscriptionResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// GetSubscriptionById - method returns a pointer to "Subscription"
+func (svc *SubscriptionService) GetSubscriptionById(id string) (*nimbleos.Subscription, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetSubscriptionById: invalid parameter specified, %v", id)
+	}
+
+	subscriptionResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// DeleteSubscription - deletes the "Subscription"
+func (svc *SubscriptionService) DeleteSubscription(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteSubscription: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/service/token_service.go
+++ b/pkg/service/token_service.go
@@ -24,10 +24,6 @@ func NewTokenService(gs *NsGroupService) *TokenService {
 
 // GetTokens - method returns a array of pointers of type "Tokens"
 func (svc *TokenService) GetTokens(params *param.GetParams) ([]*nimbleos.Token, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetTokens: invalid parameter specified, %v", params)
-	}
-
 	tokenResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/user_group_service.go
+++ b/pkg/service/user_group_service.go
@@ -24,10 +24,6 @@ func NewUserGroupService(gs *NsGroupService) *UserGroupService {
 
 // GetUserGroups - method returns a array of pointers of type "UserGroups"
 func (svc *UserGroupService) GetUserGroups(params *param.GetParams) ([]*nimbleos.UserGroup, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetUserGroups: invalid parameter specified, %v", params)
-	}
-
 	userGroupResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/user_policy_service.go
+++ b/pkg/service/user_policy_service.go
@@ -24,10 +24,6 @@ func NewUserPolicyService(gs *NsGroupService) *UserPolicyService {
 
 // GetUserPolicies - method returns a array of pointers of type "UserPolicies"
 func (svc *UserPolicyService) GetUserPolicies(params *param.GetParams) ([]*nimbleos.UserPolicy, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetUserPolicies: invalid parameter specified, %v", params)
-	}
-
 	userPolicyResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -24,10 +24,6 @@ func NewUserService(gs *NsGroupService) *UserService {
 
 // GetUsers - method returns a array of pointers of type "Users"
 func (svc *UserService) GetUsers(params *param.GetParams) ([]*nimbleos.User, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetUsers: invalid parameter specified, %v", params)
-	}
-
 	userResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/version_service.go
+++ b/pkg/service/version_service.go
@@ -24,10 +24,6 @@ func NewVersionService(gs *NsGroupService) *VersionService {
 
 // GetVersions - method returns a array of pointers of type "Versions"
 func (svc *VersionService) GetVersions(params *param.GetParams) ([]*nimbleos.Version, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetVersions: invalid parameter specified, %v", params)
-	}
-
 	versionResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/volume_collection_service.go
+++ b/pkg/service/volume_collection_service.go
@@ -25,10 +25,6 @@ func NewVolumeCollectionService(gs *NsGroupService) *VolumeCollectionService {
 
 // GetVolumeCollections - method returns a array of pointers of type "VolumeCollections"
 func (svc *VolumeCollectionService) GetVolumeCollections(params *param.GetParams) ([]*nimbleos.VolumeCollection, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetVolumeCollections: invalid parameter specified, %v", params)
-	}
-
 	volumeCollectionResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/volume_service.go
+++ b/pkg/service/volume_service.go
@@ -25,10 +25,6 @@ func NewVolumeService(gs *NsGroupService) *VolumeService {
 
 // GetVolumes - method returns a array of pointers of type "Volumes"
 func (svc *VolumeService) GetVolumes(params *param.GetParams) ([]*nimbleos.Volume, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetVolumes: invalid parameter specified, %v", params)
-	}
-
 	volumeResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err

--- a/pkg/service/volume_service_test.go
+++ b/pkg/service/volume_service_test.go
@@ -3,13 +3,14 @@
 package service
 
 import (
+	"os"
+	"testing"
+
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/param/pagination"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 type VolumeServiceTestSuite struct {
@@ -25,7 +26,7 @@ type VolumeServiceTestSuite struct {
 
 func (suite *VolumeServiceTestSuite) config() *NsGroupService {
 
-	groupService, err := NewNsGroupService("10.18.174.8", "xxx", "xxx", "v1", true)
+	groupService, err := NewNsGroupService("1.1.1.1", "xxx", "xxx", "v1", true)
 	if err != nil {
 		suite.T().Errorf("NewGroupService(): Unable to connect to group, err: %v", err.Error())
 		return nil
@@ -344,6 +345,15 @@ func (suite *VolumeServiceTestSuite) TestExpiredToken() {
 		suite.groupService.client.SessionToken = "9d255b36c700ec8b56e2064e67f01c45"
 		suite.deleteVolume("TestExpiredToken")
 	}
+}
+func (suite *VolumeServiceTestSuite) TestGetVolumes() {
+
+	volumes, err := suite.volumeService.GetVolumes(nil)
+	if err != nil || len(volumes) == 0 {
+		suite.T().Errorf("TestGetVolumes(): Unable to fetch volumes, err: %v", err.Error())
+		return
+	}
+
 }
 
 // Runs all test via go test

--- a/pkg/service/witness_service.go
+++ b/pkg/service/witness_service.go
@@ -24,10 +24,6 @@ func NewWitnessService(gs *NsGroupService) *WitnessService {
 
 // GetWitnesses - method returns a array of pointers of type "Witnesses"
 func (svc *WitnessService) GetWitnesses(params *param.GetParams) ([]*nimbleos.Witness, error) {
-	if params == nil {
-		return nil, fmt.Errorf("GetWitnesses: invalid parameter specified, %v", params)
-	}
-
 	witnessResp, err := svc.objectSet.GetObjectListFromParams(params)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Problem:
User cannot specify nil param to GetVolumes request 
Fix:
Removed NIL check in service layer for Get() response. As it is not require since user may or may not pass "param" to Get() request. 
Also, there are additional generated objects due to SM repo sync as part of this PR. 

Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>