### PR TITLE
Provided fakservice support for unit testing

### DIFF
--- a/pkg/fakeservice/group_service_factory.go
+++ b/pkg/fakeservice/group_service_factory.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package fakeservice
+
+// NsGroupService type
+type NsGroupService struct {
+	ip string
+	// Declare all the supported services
+	volumeService *VolumeService
+	poolService   *PoolService
+}
+
+// NewNsGroupService - initializes NsGroupService
+func NewNsGroupService(ip, username, password, apiVersion string, synchronous bool) (gs *NsGroupService, err error) {
+
+	return &NsGroupService{ip: ip}, nil
+}
+
+// LogoutService - delete the session token
+func (gs *NsGroupService) LogoutService() error {
+	return nil
+}
+
+// GetVolumeService - returns service of a type *VolumeService
+func (gs *NsGroupService) GetVolumeService() (vs *VolumeService) {
+	if gs.volumeService == nil {
+		gs.volumeService = NewVolumeService(gs)
+	}
+	return gs.volumeService
+}
+
+// GetPoolService - returns service of a type *PoolService
+func (gs *NsGroupService) GetPoolService() (vs *PoolService) {
+	if gs.poolService == nil {
+		gs.poolService = NewPoolService(gs)
+	}
+	return gs.poolService
+}

--- a/pkg/fakeservice/pool_service.go
+++ b/pkg/fakeservice/pool_service.go
@@ -5,6 +5,8 @@ package fakeservice
 // Pool Service - Manage pools. Pools are an aggregation of arrays.
 
 import (
+	"fmt"
+
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
 )
@@ -12,6 +14,7 @@ import (
 // PoolService type
 type PoolService struct {
 	// create a map
+	PoolMemory map[string]*nimbleos.Pool
 }
 
 // NewPoolService - method to initialize "PoolService"
@@ -22,32 +25,59 @@ func NewPoolService(gs *NsGroupService) *PoolService {
 
 // GetPools - method returns a array of pointers of type "Pools"
 func (svc *PoolService) GetPools(params *param.GetParams) ([]*nimbleos.Pool, error) {
-	return nil, nil
+	var pools []*nimbleos.Pool
+	for _, v := range svc.PoolMemory {
+		pools = append(pools, v)
+	}
+	return pools, nil
 }
 
 // CreatePool - method creates a "Pool"
 func (svc *PoolService) CreatePool(obj *nimbleos.Pool) (*nimbleos.Pool, error) {
-	return nil, nil
+	if svc.PoolMemory == nil {
+		svc.PoolMemory = make(map[string]*nimbleos.Pool)
+	}
+	if _, ok := svc.PoolMemory[*obj.ID]; !ok {
+		svc.PoolMemory[*obj.ID] = obj
+	} else {
+		return nil, fmt.Errorf("object already exists, duplicate pool %v", obj.Name)
+	}
+	return obj, nil
 }
 
 // UpdatePool - method modifies  the "Pool"
 func (svc *PoolService) UpdatePool(id string, obj *nimbleos.Pool) (*nimbleos.Pool, error) {
-	return nil, nil
+	if _, ok := svc.PoolMemory[id]; ok {
+		svc.PoolMemory[id] = obj
+	} else {
+		return nil, fmt.Errorf("object doesn't exist, failed to update pool %v", obj.Name)
+	}
+	return obj, nil
 }
 
 // GetPoolById - method returns a pointer to "Pool"
 func (svc *PoolService) GetPoolById(id string) (*nimbleos.Pool, error) {
+	if _, ok := svc.PoolMemory[id]; ok {
+		return svc.PoolMemory[id], nil
+	}
 	return nil, nil
 }
 
 // GetPoolByName - method returns a pointer "Pool"
 func (svc *PoolService) GetPoolByName(name string) (*nimbleos.Pool, error) {
+	for _, v := range svc.PoolMemory {
+		if *v.Name == name {
+			return v, nil
+		}
+	}
 	return nil, nil
 }
 
 // DeletePool - deletes the "Pool"
 func (svc *PoolService) DeletePool(id string) error {
-
+	if _, ok := svc.PoolMemory[id]; ok {
+		delete(svc.PoolMemory, id)
+	}
 	return nil
 }
 
@@ -60,6 +90,8 @@ func (svc *PoolService) DeletePool(id string) error {
 //       force - Forcibly merge the specified pool into target pool.
 
 func (svc *PoolService) MergePool(id string, targetPoolId string, force *bool) (*nimbleos.NsPoolMergeReturn, error) {
-
+	if _, ok := svc.PoolMemory[id]; ok {
+		delete(svc.PoolMemory, id)
+	}
 	return nil, nil
 }

--- a/pkg/fakeservice/pool_service.go
+++ b/pkg/fakeservice/pool_service.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package fakeservice
+
+// Pool Service - Manage pools. Pools are an aggregation of arrays.
+
+import (
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// PoolService type
+type PoolService struct {
+	// create a map
+}
+
+// NewPoolService - method to initialize "PoolService"
+func NewPoolService(gs *NsGroupService) *PoolService {
+
+	return &PoolService{}
+}
+
+// GetPools - method returns a array of pointers of type "Pools"
+func (svc *PoolService) GetPools(params *param.GetParams) ([]*nimbleos.Pool, error) {
+	return nil, nil
+}
+
+// CreatePool - method creates a "Pool"
+func (svc *PoolService) CreatePool(obj *nimbleos.Pool) (*nimbleos.Pool, error) {
+	return nil, nil
+}
+
+// UpdatePool - method modifies  the "Pool"
+func (svc *PoolService) UpdatePool(id string, obj *nimbleos.Pool) (*nimbleos.Pool, error) {
+	return nil, nil
+}
+
+// GetPoolById - method returns a pointer to "Pool"
+func (svc *PoolService) GetPoolById(id string) (*nimbleos.Pool, error) {
+	return nil, nil
+}
+
+// GetPoolByName - method returns a pointer "Pool"
+func (svc *PoolService) GetPoolByName(name string) (*nimbleos.Pool, error) {
+	return nil, nil
+}
+
+// DeletePool - deletes the "Pool"
+func (svc *PoolService) DeletePool(id string) error {
+
+	return nil
+}
+
+// MergePool - merge the specified pool into the target pool. All volumes on the specified pool are moved to the target pool and the specified pool is then deleted. All the arrays in the pool are assigned to the target pool.
+//   Required parameters:
+//       id - ID of the specified pool.
+//       targetPoolId - ID of the target pool.
+
+//   Optional parameters:
+//       force - Forcibly merge the specified pool into target pool.
+
+func (svc *PoolService) MergePool(id string, targetPoolId string, force *bool) (*nimbleos.NsPoolMergeReturn, error) {
+
+	return nil, nil
+}

--- a/pkg/fakeservice/volume_service.go
+++ b/pkg/fakeservice/volume_service.go
@@ -1,0 +1,145 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package fakeservice
+
+// Volume Service - Volumes are the basic storage units from which the total capacity is apportioned. The terms volume and LUN are used interchangeably.The number of volumes per array depends on
+// storage allocation.
+
+import (
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// VolumeService type
+type VolumeService struct {
+	// create a map
+}
+
+// NewVolumeService - method to initialize "VolumeService"
+func NewVolumeService(gs *NsGroupService) *VolumeService {
+
+	return &VolumeService{}
+}
+
+// GetVolumes - method returns a array of pointers of type "Volumes"
+func (svc *VolumeService) GetVolumes(params *param.GetParams) ([]*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// CreateVolume - method creates a "Volume"
+func (svc *VolumeService) CreateVolume(obj *nimbleos.Volume) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// UpdateVolume - method modifies  the "Volume"
+func (svc *VolumeService) UpdateVolume(id string, obj *nimbleos.Volume) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// GetVolumeById - method returns a pointer to "Volume"
+func (svc *VolumeService) GetVolumeById(id string) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// GetVolumeByName - method returns a pointer "Volume"
+func (svc *VolumeService) GetVolumeByName(name string) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// GetVolumeBySerialNumber method returns a pointer to "Volume"
+func (svc *VolumeService) GetVolumeBySerialNumber(serialNumber string) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+//OnlineVolume - method makes the volume online
+func (svc *VolumeService) OnlineVolume(id string, force bool) (*nimbleos.Volume, error) {
+	return nil, nil
+}
+
+// OfflineVolume - makes the volume offline
+func (svc *VolumeService) OfflineVolume(id string, force bool) (*nimbleos.Volume, error) {
+	return nil, nil
+
+}
+
+// DeleteVolume - deletes the volume
+func (svc *VolumeService) DeleteVolume(id string) error {
+	return nil
+}
+
+// AssociateVolume - add a volume to a volume collection
+func (svc *VolumeService) AssociateVolume(volId string, volcollId string) error {
+
+	return nil
+}
+
+// DisassociateVolume - remove a volume from a volume collection
+func (svc *VolumeService) DisassociateVolume(volId string) error {
+
+	return nil
+
+}
+
+// RestoreVolume - restore volume data from a previous snapshot.
+//   Required parameters:
+//       id - ID of the restored volume.
+//       baseSnapId - ID of the snapshot to which this the volume is restored.
+
+func (svc *VolumeService) RestoreVolume(id string, baseSnapId string) error {
+
+	return nil
+}
+
+// MoveVolume - move a volume and its related volumes to another pool. To change a single volume's folder assignment (while remaining in the same pool), use a volume update operation to change the folder_id attribute.
+//   Required parameters:
+//       id - ID of the volume to move.
+//       destPoolId - ID of the destination pool or folder. Specify a pool ID when the volumes should not be in a folder; otherwise, specify a folder ID and the pool will be derived from the folder.
+
+//   Optional parameters:
+//       forceVvol - Forcibly move a Virtual Volume. Moving Virtual Volume is disruptive to the vCenter, hence it should only be done by the VASA Provider (VP). This flag should only be set by the VP when it calls this API.
+
+func (svc *VolumeService) MoveVolume(id string, destPoolId string, forceVvol *bool) (*nimbleos.NsVolumeListReturn, error) {
+
+	return nil, nil
+}
+
+// BulkMoveVolumes - move volumes and their related volumes to another pool. To change a single volume's folder assignment (while remaining in the same pool), use a volume update operation to change the folder_id attribute.
+//   Required parameters:
+//       volIds - IDs of the volumes to move.
+//       destPoolId - ID of the destination pool or folder. Specify a pool ID when the volumes should not be in a folder; otherwise, specify a folder ID and the pool will be derived from the folder.
+
+//   Optional parameters:
+//       forceVvol - Forcibly move a Virtual Volume. Moving Virtual Volume is disruptive to the vCenter, hence it should only be done by the VASA Provider (VP). This flag should only be set by the VP when it calls this API.
+
+func (svc *VolumeService) BulkMoveVolumes(volIds []*string, destPoolId string, forceVvol *bool) (*nimbleos.NsVolumeListReturn, error) {
+	return nil, nil
+}
+
+// AbortMoveVolume - abort the in-progress move of the specified volume to another pool.
+//   Required parameters:
+//       id - ID of the volume to stop moving to a different pool.
+
+func (svc *VolumeService) AbortMoveVolume(id string) error {
+
+	return nil
+}
+
+// BulkSetDedupeVolumes - enable or disable dedupe on a list of volumes. If the volumes are not dedupe capable, the operation will fail for the specified volume.
+//   Required parameters:
+//       volIds - IDs of the volumes to enable/disable dedupe.
+//       dedupeEnabled - Dedupe property to be applied to the list of volumes.
+
+func (svc *VolumeService) BulkSetDedupeVolumes(volIds []*string, dedupeEnabled bool) error {
+
+	return nil
+}
+
+// BulkSetOnlineAndOfflineVolumes - bring a list of volumes online or offline.
+//   Required parameters:
+//       volIds - IDs of the volumes to set online or offline.
+//       online - Desired state of the volumes. "true" for online, "false" for offline.
+
+func (svc *VolumeService) BulkSetOnlineAndOfflineVolumes(volIds []*string, online bool) error {
+
+	return nil
+}

--- a/pkg/service/snapshot_service.go
+++ b/pkg/service/snapshot_service.go
@@ -72,13 +72,13 @@ func (svc *SnapshotService) GetSnapshotById(id string) (*nimbleos.Snapshot, erro
 	return snapshotResp, nil
 }
 
-// GetSnapshotByName - method returns a pointer "Snapshot"
-func (svc *SnapshotService) GetSnapshotByName(name string) (*nimbleos.Snapshot, error) {
+// GetSnapshotByName - method returns a list of pointers to "Snapshot"
+func (svc *SnapshotService) GetSnapshotByName(volName string) ([]*nimbleos.Snapshot, error) {
 	params := &param.GetParams{
 		Filter: &param.SearchFilter{
-			FieldName: nimbleos.VolumeFields.Name,
+			FieldName: nimbleos.SnapshotFields.VolName,
 			Operator:  param.EQUALS.String(),
-			Value:     name,
+			Value:     volName,
 		},
 	}
 	snapshotResp, err := svc.objectSet.GetObjectListFromParams(params)
@@ -89,8 +89,7 @@ func (svc *SnapshotService) GetSnapshotByName(name string) (*nimbleos.Snapshot, 
 	if len(snapshotResp) == 0 {
 		return nil, nil
 	}
-
-	return snapshotResp[0], nil
+	return snapshotResp, nil
 }
 
 // GetSnapshotBySerialNumber method returns a pointer to "Snapshot"


### PR DESCRIPTION
Bug : SA-172
Implementation:
Added the framework to support fake services for unit testing. Initially added volume_service and pool_service. 
User has to call fakeservice package instead of service package for NewNsGroupService() 

Example 
```
        package main

import (
        "fmt"

        "github.hpe.com/nimble-dcs/golang-sdk/pkg/client/v1/nimbleos"
        "github.hpe.com/nimble-dcs/golang-sdk/pkg/param"
        "github.hpe.com/nimble-dcs/golang-sdk/pkg/fakeservice"
)

func main() {
        groupService, err := fakeservice.NewNsGroupService("1.1.1.1", "xxx", "xxx", "v1", false)
        if err != nil {
                fmt.Printf("NewGroupService(): Unable to connect to group, err: %v", err.Error())
                return
        }
        // set debug
        //groupService.SetDebug()
        defer groupService.LogoutService()
        // get  volume service instance
        volSvc := groupService.GetVolumeService()
        // Initialize volume attributes
        var sizeField int64 = 5120
        descriptionField := "This volume was created as part of a unit test"
        var limitIopsField int64 = 256
        var limitMbpsField int64 = 1

        // set volume attributes
        newVolume := &nimbleos.Volume{
                ID:                param.NewString("0677654354e496314900000000000000000000000b"),
                Name:              param.NewString("TestDemo1"),
                Size:              &sizeField,
                Description:       &descriptionField,
                ThinlyProvisioned: param.NewBool(true),
                Online:            param.NewBool(true),
                LimitIops:         &limitIopsField,
                LimitMbps:         &limitMbpsField,
                MultiInitiator:    param.NewBool(true),
                AgentType:         nimbleos.NsAgentTypeNone,
        }

        // create volume
        volume, err := volSvc.CreateVolume(newVolume)

        if err != nil {
                fmt.Printf("Failed to create volume, err ", err)
                return
        }
        fmt.Printf("vol : %+v", volume)
        // delete volume, cleanup
        volSvc.DeleteVolume(*volume.ID)

        fmt.Printf("error : %v", err)
        _, err = volSvc.GetVolumeById(*volume.ID)
        fmt.Printf("error : %v", err)

        poolSvc := groupService.GetPoolService()
        p, _ := poolSvc.GetPools(nil)
        fmt.Printf("pool %v", p)

}
```


Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>