### PR TITLE
CreatePool method was missing from interface definition, fixed it

### DIFF
--- a/pkg/sdkprovider/sdk_provider.go
+++ b/pkg/sdkprovider/sdk_provider.go
@@ -30,6 +30,7 @@ type VolumeService interface {
 // PoolService defines the interface to Pool related operations
 type PoolService interface {
 	GetPools(params *param.GetParams) ([]*nimbleos.Pool, error)
+	CreatePool(obj *nimbleos.Pool) (*nimbleos.Pool, error)
 	UpdatePool(id string, obj *nimbleos.Pool) (*nimbleos.Pool, error)
 	GetPoolById(id string) (*nimbleos.Pool, error)
 	GetPoolByName(name string) (*nimbleos.Pool, error)


### PR DESCRIPTION
Fix :
Added CreatePool method signature to the interface definition 
Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>