### PR TITLE
Rep Partner, FC and fixes

### DIFF
--- a/test/common.go
+++ b/test/common.go
@@ -16,16 +16,16 @@ const defaultVolumeName = "DefaultVolumeTest"
 const defaultInitiatorGrpName = "DefaultInitiatorgrpTest"
 const defaultVolCollName = "DefaultVolCollTest"
 
-var arrayIP = flag.String("arrayIP", "1.1.1.1", "Array IP")
+var arrayIP = flag.String("arrayIP", "", "Array IP")
 
 var arrayUsername = flag.String("arrayUsername", "xxx", "Array Username")
 
 var arrayPassword = flag.String("arrayPassword", "xxx", "Array Password")
 
-var downstreamArrayIP = flag.String("downstream", "", "Array IP to be used as downstream")
+var downstreamArrayIP = flag.String("downstream", "", "IP address of an array to be used as a downstream replica. Pass this IP to execute replication partner test cases.")
 
 // Required for group merge test
-var sourceArrayIP = flag.String("sourceArrayIP", "1.1.1.2", "Source array IP for group tests")
+var sourceArrayIP = flag.String("sourceArrayIP", "", "IP address of source array, used for group and merge test cases.")
 
 var sourceArrayusername = flag.String("sourceArrayusername", "xxx", "Source array username")
 
@@ -99,14 +99,20 @@ func isFCEnabled(arrayGroupService *service.GroupService) bool {
 	filter := &param.GetParams{}
 	groups, _ := arrayGroupService.GetGroups(filter)
 	group := groups[0]
-	return *group.FcEnabled
+	if group != nil {
+		return *group.FcEnabled
+	}
+	return false
 }
 
 func isIscsiEnabled(arrayGroupService *service.GroupService) bool {
 	filter := &param.GetParams{}
 	groups, _ := arrayGroupService.GetGroups(filter)
 	group := groups[0]
-	return *group.IscsiEnabled
+	if group != nil {
+		return *group.IscsiEnabled
+	}
+	return false
 }
 
 func getArrayVersion(groupService *service.GroupService) float64 {

--- a/test/fibre_channel_test.go
+++ b/test/fibre_channel_test.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package test
+
+import (
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type FiberChannelWorkflowSuite struct {
+	suite.Suite
+	groupService       *service.NsGroupService
+	fcConfigService    *service.FibreChannelConfigService
+	fcInterfaceService *service.FibreChannelInterfaceService
+	arrayGroupService  *service.GroupService
+}
+
+func (suite *FiberChannelWorkflowSuite) SetupSuite() {
+	groupService, err := config()
+	assert.Nilf(suite.T(), err, "Unable to connect to group, err: %v", err)
+	suite.groupService = groupService
+	suite.fcConfigService = groupService.GetFibreChannelConfigService()
+	suite.fcInterfaceService = groupService.GetFibreChannelInterfaceService()
+	suite.arrayGroupService = groupService.GetGroupService()
+	if !isFCEnabled(suite.arrayGroupService) {
+		suite.T().SkipNow()
+	}
+}
+
+func (suite *FiberChannelWorkflowSuite) TearDownSuite() {
+	suite.groupService.LogoutService()
+}
+
+func (suite *FiberChannelWorkflowSuite) TestFiberChannelOfflineOnline() {
+	filter := &param.GetParams{}
+	interfaces, _ := suite.fcInterfaceService.GetFibreChannelInterfaces(filter)
+	var interfaceID *string = nil
+	for i := 0; i < len(interfaces); i++ {
+		if *interfaces[i].Online == true {
+			interfaceID = interfaces[i].ID
+			break
+		}
+	}
+	if interfaceID != nil {
+		offlineInterface := &nimbleos.FibreChannelInterface{
+			Online: param.NewBool(false),
+		}
+		_, err := suite.fcInterfaceService.UpdateFibreChannelInterface(*interfaceID, offlineInterface)
+		assert.Nilf(suite.T(), err, "Unable to set interface offline, err: %v", err)
+		onlineInterface := &nimbleos.FibreChannelInterface{
+			Online: param.NewBool(true),
+		}
+		_, err = suite.fcInterfaceService.UpdateFibreChannelInterface(*interfaces[0].ID, onlineInterface)
+		assert.Nilf(suite.T(), err, "Unable to set interface to online, err: %v", err)
+	}
+}
+
+func (suite *FiberChannelWorkflowSuite) TestRegenerateOnlineInterfaces() {
+	filter := &param.GetParams{}
+	fcs, _ := suite.fcConfigService.GetFibreChannelConfigs(filter)
+	interfaces, _ := suite.fcInterfaceService.GetFibreChannelInterfaces(filter)
+	for i := 0; i < len(interfaces); i++ {
+		if *interfaces[i].Online == true {
+			_, err := suite.fcConfigService.RegenerateFibreChannelConfig(*fcs[0].ID, "af:32:f1", true)
+			assert.NotNil(suite.T(), err, "Regenerating Fiber channel config with online interfaces should have failed")
+		}
+	}
+}
+
+func TestFiberChannelWorkflowSuite(t *testing.T) {
+	suite.Run(t, new(FiberChannelWorkflowSuite))
+}

--- a/test/initiator_group_test.go
+++ b/test/initiator_group_test.go
@@ -20,8 +20,6 @@ type IGWorkflowSuite struct {
 	initiatorGrpService *service.InitiatorGroupService
 	volumeService       sdkprovider.VolumeService
 	arrayGroupService   *service.GroupService
-	fcEnabled           bool
-	iscsiEnabled        bool
 }
 
 func (suite *IGWorkflowSuite) SetupSuite() {
@@ -75,9 +73,8 @@ func (suite *IGWorkflowSuite) TestCreateIG() {
 	updateIG := &nimbleos.InitiatorGroup{
 		Description: newDesc,
 	}
-	if ig != nil {
-		suite.initiatorGrpService.UpdateInitiatorGroup(*ig.ID, updateIG)
-	}
+	_, err = suite.initiatorGrpService.UpdateInitiatorGroup(*ig.ID, updateIG)
+	assert.Nilf(suite.T(), err, "Unable to update initiator group, err: %v", err)
 	ig, _ = suite.initiatorGrpService.GetInitiatorGroupByName(initiatorGroupName)
 	assert.Equal(suite.T(), *newDesc, *ig.Description, "Unable to update Initiator Group")
 
@@ -114,9 +111,9 @@ func (suite *IGWorkflowSuite) TestCreateIGIscsiInitiators() {
 	_, err := suite.initiatorGrpService.CreateInitiatorGroup(newIG)
 	assert.Nilf(suite.T(), err, "Unable to create initiator group, err: %v", err)
 	// Update initiator group
-	var ipAdd *string = param.NewString("10.1.0.0")
+	ipAdd := "10.1.0.0"
 	updateIscsiInitiator := &nimbleos.NsISCSIInitiator{
-		IpAddress: ipAdd,
+		IpAddress: &ipAdd,
 		Label:     param.NewString("NewLabel"),
 	}
 	var updatedInitiatorList []*nimbleos.NsISCSIInitiator
@@ -127,7 +124,7 @@ func (suite *IGWorkflowSuite) TestCreateIGIscsiInitiators() {
 	currentIG, _ := suite.initiatorGrpService.GetInitiatorGroupByName("TestIGIscsi")
 	_, err = suite.initiatorGrpService.UpdateInitiatorGroup(*currentIG.ID, updateIG)
 	assert.Nilf(suite.T(), err, "Modifying IP address of initiator failed: %v", err)
-	assert.Equal(suite.T(), *ipAdd, *updateIG.IscsiInitiators[0].IpAddress, "Updating iscsi initiators failed")
+	assert.Equal(suite.T(), ipAdd, *updateIG.IscsiInitiators[0].IpAddress, "Updating iscsi initiators failed")
 	// Clean up
 	suite.deleteInitiatorGroup("TestIGIscsi")
 }

--- a/test/initiator_group_test.go
+++ b/test/initiator_group_test.go
@@ -19,6 +19,9 @@ type IGWorkflowSuite struct {
 	groupService        *service.NsGroupService
 	initiatorGrpService *service.InitiatorGroupService
 	volumeService       sdkprovider.VolumeService
+	arrayGroupService   *service.GroupService
+	fcEnabled           bool
+	iscsiEnabled        bool
 }
 
 func (suite *IGWorkflowSuite) SetupSuite() {
@@ -29,11 +32,10 @@ func (suite *IGWorkflowSuite) SetupSuite() {
 	suite.volumeService = groupService.GetVolumeService()
 	_, err = createDefaultVolume(suite.volumeService)
 	assert.Nilf(suite.T(), err, "Unable to create default volume, err: %v", err)
+	suite.arrayGroupService = groupService.GetGroupService()
 }
 
 func (suite *IGWorkflowSuite) TearDownSuite() {
-	suite.deleteInitiatorGroup("TestIGIscsi")
-	suite.deleteInitiatorGroup(initiatorGroupName)
 	err := deleteDefaultVolume(suite.volumeService)
 	assert.Nilf(suite.T(), err, "Unable to delete default volume, err: %v", err)
 	suite.groupService.LogoutService()
@@ -56,6 +58,9 @@ func (suite *IGWorkflowSuite) TestCreateIGMissingParam() {
 }
 
 func (suite *IGWorkflowSuite) TestCreateIG() {
+	if !isIscsiEnabled(suite.arrayGroupService) {
+		suite.T().Skip()
+	}
 	var desc *string = param.NewString("Workflow initiator group")
 	newIG := &nimbleos.InitiatorGroup{
 		Name:           param.NewString(initiatorGroupName),
@@ -66,19 +71,33 @@ func (suite *IGWorkflowSuite) TestCreateIG() {
 	assert.Nilf(suite.T(), err, "Unable to create initiator group, err: %v", err)
 	ig, _ := suite.initiatorGrpService.GetInitiatorGroupByName(initiatorGroupName)
 	assert.Equal(suite.T(), *desc, *ig.Description, "Initiator group creation does not have expected description.")
-}
+	var newDesc *string = param.NewString("Workflow tests for initiator group")
+	updateIG := &nimbleos.InitiatorGroup{
+		Description: newDesc,
+	}
+	if ig != nil {
+		suite.initiatorGrpService.UpdateInitiatorGroup(*ig.ID, updateIG)
+	}
+	ig, _ = suite.initiatorGrpService.GetInitiatorGroupByName(initiatorGroupName)
+	assert.Equal(suite.T(), *newDesc, *ig.Description, "Unable to update Initiator Group")
 
-func (suite *IGWorkflowSuite) TestCreateIGDuplicate() {
+	// Create duplicate - should fail
 	dupIG := &nimbleos.InitiatorGroup{
 		Name:           param.NewString(initiatorGroupName),
 		Description:    param.NewString("Workflow initiator group"),
 		AccessProtocol: nimbleos.NsAccessProtocolIscsi,
 	}
-	_, err := suite.initiatorGrpService.CreateInitiatorGroup(dupIG)
+	_, err = suite.initiatorGrpService.CreateInitiatorGroup(dupIG)
 	assert.NotNil(suite.T(), err, "Initiator group creation should have failed")
+
+	// Clean up
+	suite.deleteInitiatorGroup(initiatorGroupName)
 }
 
 func (suite *IGWorkflowSuite) TestCreateIGIscsiInitiators() {
+	if !isIscsiEnabled(suite.arrayGroupService) {
+		suite.T().Skip()
+	}
 	iscsiInitiator := &nimbleos.NsISCSIInitiator{
 		Label:     param.NewString("initiator1"),
 		Iqn:       param.NewString("iqn.1994-05.com.redhat:48e040d53bf6"),
@@ -94,9 +113,49 @@ func (suite *IGWorkflowSuite) TestCreateIGIscsiInitiators() {
 	}
 	_, err := suite.initiatorGrpService.CreateInitiatorGroup(newIG)
 	assert.Nilf(suite.T(), err, "Unable to create initiator group, err: %v", err)
+	// Update initiator group
+	var ipAdd *string = param.NewString("10.1.0.0")
+	updateIscsiInitiator := &nimbleos.NsISCSIInitiator{
+		IpAddress: ipAdd,
+		Label:     param.NewString("NewLabel"),
+	}
+	var updatedInitiatorList []*nimbleos.NsISCSIInitiator
+	updatedInitiatorList = append(updatedInitiatorList, updateIscsiInitiator)
+	updateIG := &nimbleos.InitiatorGroup{
+		IscsiInitiators: updatedInitiatorList,
+	}
+	currentIG, _ := suite.initiatorGrpService.GetInitiatorGroupByName("TestIGIscsi")
+	_, err = suite.initiatorGrpService.UpdateInitiatorGroup(*currentIG.ID, updateIG)
+	assert.Nilf(suite.T(), err, "Modifying IP address of initiator failed: %v", err)
+	assert.Equal(suite.T(), *ipAdd, *updateIG.IscsiInitiators[0].IpAddress, "Updating iscsi initiators failed")
+	// Clean up
+	suite.deleteInitiatorGroup("TestIGIscsi")
+}
+
+func (suite *IGWorkflowSuite) TestCreateFCInitiators() {
+	if !isFCEnabled(suite.arrayGroupService) {
+		suite.T().Skip()
+	}
+	fcInitiator := &nimbleos.NsFCInitiator{
+		Wwpn: param.NewString("af:32:f1:20:bc:ba:43:1a"),
+	}
+	var fcList []*nimbleos.NsFCInitiator
+	fcList = append(fcList, fcInitiator)
+	newIG := &nimbleos.InitiatorGroup{
+		Name:           param.NewString("TestIGFC"),
+		Description:    param.NewString("Workflow initiator group"),
+		AccessProtocol: nimbleos.NsAccessProtocolFc,
+		FcInitiators:   fcList,
+	}
+	_, err := suite.initiatorGrpService.CreateInitiatorGroup(newIG)
+	assert.Nilf(suite.T(), err, "Unable to create initiator group, err: %v", err)
+	suite.deleteInitiatorGroup("TestIGFC")
 }
 
 func (suite *IGWorkflowSuite) TestCreateIGInvalidIscsi() {
+	if !isIscsiEnabled(suite.arrayGroupService) {
+		suite.T().Skip()
+	}
 	iscsiInitiator := &nimbleos.NsISCSIInitiator{
 		Label:     param.NewString("initiator1"),
 		Iqn:       param.NewString("a"),
@@ -112,36 +171,6 @@ func (suite *IGWorkflowSuite) TestCreateIGInvalidIscsi() {
 	}
 	_, err := suite.initiatorGrpService.CreateInitiatorGroup(newIG)
 	assert.NotNil(suite.T(), err, "Initiator group creation with invalid iscsi initiators should have failed")
-}
-
-func (suite *IGWorkflowSuite) TestModifyIGDescription() {
-	var desc *string = param.NewString("Workflow tests for initiator group")
-	updateIG := &nimbleos.InitiatorGroup{
-		Description: desc,
-	}
-	ig, _ := suite.initiatorGrpService.GetInitiatorGroupByName(initiatorGroupName)
-	if ig != nil {
-		suite.initiatorGrpService.UpdateInitiatorGroup(*ig.ID, updateIG)
-	}
-	ig, _ = suite.initiatorGrpService.GetInitiatorGroupByName(initiatorGroupName)
-	assert.Equal(suite.T(), *desc, *ig.Description, "Unable to update Initiator Group")
-}
-
-func (suite *IGWorkflowSuite) TestModifyIGInitiators() {
-	var ipAdd *string = param.NewString("10.1.0.0")
-	iscsiInitiator := &nimbleos.NsISCSIInitiator{
-		IpAddress: ipAdd,
-		Label:     param.NewString("NewLabel"),
-	}
-	var initiatorList []*nimbleos.NsISCSIInitiator
-	initiatorList = append(initiatorList, iscsiInitiator)
-	updateIG := &nimbleos.InitiatorGroup{
-		IscsiInitiators: initiatorList,
-	}
-	currentIG, _ := suite.initiatorGrpService.GetInitiatorGroupByName("TestIGIscsi")
-	_, err := suite.initiatorGrpService.UpdateInitiatorGroup(*currentIG.ID, updateIG)
-	assert.Nilf(suite.T(), err, "Modifying IP address of initiator failed: %v", err)
-	assert.Equal(suite.T(), *ipAdd, *updateIG.IscsiInitiators[0].IpAddress, "Updating iscsi initiators failed")
 }
 
 func TestInitiatorGroupSuite(t *testing.T) {

--- a/test/network_test.go
+++ b/test/network_test.go
@@ -39,6 +39,10 @@ func (suite *NetworkWorkflowSuite) SetupSuite() {
 	suite.networkConfigService = groupService.GetNetworkConfigService()
 }
 
+func (suite *NetworkWorkflowSuite) TearDownSuite() {
+	suite.groupService.LogoutService()
+}
+
 func (suite *NetworkWorkflowSuite) TestCreateUpdateDeleteDraft() {
 	filter := &param.GetParams{}
 	getNetworkResp, err := suite.networkConfigService.GetNetworkConfigs(filter)

--- a/test/replication_partner_test.go
+++ b/test/replication_partner_test.go
@@ -1,0 +1,126 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+package test
+
+import (
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/sdkprovider"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+const repPartner = "ReplcationPartnerTest"
+const repPassphrase = "Nim123Boli"
+
+type ReplicationPartnerWorkflowSuite struct {
+	suite.Suite
+	groupService                *service.NsGroupService
+	downstreamGroupService      *service.NsGroupService
+	upstreamRepPartnerService   *service.ReplicationPartnerService
+	downstreamRepPartnerService *service.ReplicationPartnerService
+	upstreamArrayGrpService     *service.GroupService
+	downstreamArrayGrpService   *service.GroupService
+	upstreamGroupName           string
+	downstreamGroupName         string
+	volumeService               sdkprovider.VolumeService
+	volcollService              *service.VolumeCollectionService
+	protectionScheduleService   *service.ProtectionScheduleService
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) SetupSuite() {
+	groupService, err := config()
+	assert.Nilf(suite.T(), err, "Unable to connect to group, err: %v", err)
+	suite.groupService = groupService
+	suite.volumeService = groupService.GetVolumeService()
+	suite.upstreamRepPartnerService = groupService.GetReplicationPartnerService()
+	suite.upstreamArrayGrpService = groupService.GetGroupService()
+	filter := &param.GetParams{}
+	groupResp, _ := suite.upstreamArrayGrpService.GetGroups(filter)
+	suite.upstreamGroupName = *groupResp[0].Name
+	// Skip test run if no downstream array is passed
+	if *downstreamArrayIP == "" {
+		suite.T().SkipNow()
+	}
+	// Downstream Array
+	groupService2, err := service.NewNsGroupService(*downstreamArrayIP, "admin", "admin", "v1", true)
+	assert.Nilf(suite.T(), err, "Unable to connect to the downstream partner, err: %v", err)
+	suite.downstreamGroupService = groupService2
+	suite.downstreamRepPartnerService = groupService2.GetReplicationPartnerService()
+	suite.downstreamArrayGrpService = groupService2.GetGroupService()
+	groupResp, _ = suite.downstreamArrayGrpService.GetGroups(filter)
+	suite.downstreamGroupName = *groupResp[0].Name
+	suite.createReplicationPartner()
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) TearDownSuite() {
+	suite.deleteReplicationPartner()
+	suite.groupService.LogoutService()
+	suite.downstreamGroupService.LogoutService()
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) createReplicationPartner() {
+	// Upstream
+	upstream := &nimbleos.ReplicationPartner{
+		Name:        param.NewString(suite.downstreamGroupName),
+		Secret:      param.NewString(repPassphrase),
+		Hostname:    downstreamArrayIP,
+		SubnetLabel: param.NewString("mgmt-data"),
+	}
+	upstreamRP, err := suite.upstreamRepPartnerService.CreateReplicationPartner(upstream)
+	assert.Nilf(suite.T(), err, "Unable to set replication partner, err: %v", err)
+	// Downstream
+	downstream := &nimbleos.ReplicationPartner{
+		Name:        param.NewString(suite.upstreamGroupName),
+		Secret:      param.NewString(repPassphrase),
+		Hostname:    arrayIP,
+		SubnetLabel: param.NewString("mgmt-data"),
+	}
+	downstreamRP, err := suite.downstreamRepPartnerService.CreateReplicationPartner(downstream)
+	assert.Nilf(suite.T(), err, "Unable to set replication partner, err: %v", err)
+
+	// Test replication partner
+	err = suite.upstreamRepPartnerService.TestReplicationPartner(*upstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to test replication partners, err: %v", err)
+	err = suite.downstreamRepPartnerService.TestReplicationPartner(*downstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to test replication partners, err: %v", err)
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) deleteReplicationPartner() {
+	upstreamRP, err := suite.upstreamRepPartnerService.GetReplicationPartnerByName(suite.downstreamGroupName)
+	assert.Nilf(suite.T(), err, "Unable to find the replication partner, err: %v", err)
+	err = suite.upstreamRepPartnerService.DeleteReplicationPartner(*upstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to delete upstream replication partner, err: %v", err)
+	downstreamRP, err := suite.downstreamRepPartnerService.GetReplicationPartnerByName(suite.upstreamGroupName)
+	assert.Nilf(suite.T(), err, "Unable to find the replication partner, err: %v", err)
+	err = suite.downstreamRepPartnerService.DeleteReplicationPartner(*downstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to delete downstram replication partner, err: %v", err)
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) TestPauseResumeRP() {
+	upstreamRP, err := suite.upstreamRepPartnerService.GetReplicationPartnerByName(suite.downstreamGroupName)
+	assert.Nilf(suite.T(), err, "Unable to find replication partner, err: %v", err)
+
+	// Pause Replication Partner
+	err = suite.upstreamRepPartnerService.PauseReplicationPartner(*upstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to pause replication parner, err: %v", err)
+
+	// Resume replication partner
+	err = suite.upstreamRepPartnerService.ResumeReplicationPartner(*upstreamRP.ID)
+	assert.Nilf(suite.T(), err, "Unable to resume replication partner")
+}
+
+func (suite *ReplicationPartnerWorkflowSuite) TestUpdateRP() {
+	upstreamRP, err := suite.upstreamRepPartnerService.GetReplicationPartnerByName(suite.downstreamGroupName)
+	assert.Nilf(suite.T(), err, "Unable to find replication partner, err: %v", err)
+	updateRP := &nimbleos.ReplicationPartner{
+		Description: param.NewString("Testing replication partner"),
+	}
+	_, err = suite.upstreamRepPartnerService.UpdateReplicationPartner(*upstreamRP.ID, updateRP)
+	assert.Nilf(suite.T(), err, "Unable to update replication partner, err: %v", err)
+}
+
+func TestReplicationPartnerWorkflowSuite(t *testing.T) {
+	suite.Run(t, new(ReplicationPartnerWorkflowSuite))
+}

--- a/test/snapshot_test.go
+++ b/test/snapshot_test.go
@@ -50,6 +50,10 @@ func (suite *SnapshotWorkflowSuite) SetupSuite() {
 	suite.volumeService = groupService.GetVolumeService()
 }
 
+func (suite *SnapshotWorkflowSuite) TearDownSuite() {
+	suite.groupService.LogoutService()
+}
+
 // Create a volume/clone volume
 func (suite *SnapshotWorkflowSuite) createVolume(volumeName string, baseSnapshotID string) string {
 


### PR DESCRIPTION
Signed-off-by: pruparelia <prachi.ruparelia@hpe.com>

Changes in this PR:
- Support to pass in array details from command line
- fcenabled, iscsienabled and array version check support
- Fibrechannel and replication partner test cases
- FC initiator test cases