### PR TITLE
Bug fix SA-203 - AvgStatsLast5mins is not populating correctly as it always display nil 

### DIFF
--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -417,7 +417,7 @@ func waitForJobResult(jobId string, client *GroupMgmtClient) (interface{}, error
 
 			job, err := client.GetJobObjectSet().GetObject(jobId)
 			if err != nil {
-				fmt.Printf("Warning : failed to %s jobId info, err : %s", jobId, err.Error())
+				fmt.Printf("Warning : failed to get %s jobId info, err : %s\n", jobId, err.Error())
 			} else {
 				var objectId = *job.ObjectId
 				if string(*job.State) == string(*nimbleos.NsJobStatusDone) {

--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -417,7 +417,7 @@ func waitForJobResult(jobId string, client *GroupMgmtClient) (interface{}, error
 
 			job, err := client.GetJobObjectSet().GetObject(jobId)
 			if err != nil {
-				fmt.Println("Warning : failed to %s jobId info, err : %s", jobId, err.Error())
+				fmt.Printf("Warning : failed to %s jobId info, err : %s", jobId, err.Error())
 			} else {
 				var objectId = *job.ObjectId
 				if string(*job.State) == string(*nimbleos.NsJobStatusDone) {

--- a/pkg/client/v1/nimbleos/volume.go
+++ b/pkg/client/v1/nimbleos/volume.go
@@ -268,7 +268,7 @@ type Volume struct {
 	// PreFilter - Pre-filtering criteria.
 	PreFilter *string `json:"pre_filter,omitempty"`
 	// AvgStatsLast5mins - Average statistics in last 5 minutes.
-	AvgStatsLast5mins *NsAverageStats `json:"avg_stats_last5mins,omitempty"`
+	AvgStatsLast5mins *NsAverageStats `json:"avg_stats_last_5mins,omitempty"`
 	// SrepLastSync - Time when synchronously replicated volume was last synchronized.
 	SrepLastSync *int64 `json:"srep_last_sync,omitempty"`
 	// SrepResyncPercent - Percentage of resync progress for synchronously replicated volume.


### PR DESCRIPTION
Bug SA-203 
The volume average stats for last 5mins always display nil and doesnt poplate it correctly.

Fix :

v1/nimbleos/volume.go , file contains the definition of volume struct with supported fields and json tags. The json tag for the field AvgStatsLast5mins has a typo . It has "avg_stats_last5mins" instead of "avg_stats_last_5mins" which causes to return default value nil for AvgStatsLast5mins. Made the tag name changes to fix the issue . 

Unit test:
Ran the unit test to validate it correctly populate the filed values. 



Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>