### PR TITLE
Auto generated sdk files

### DIFF
--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -393,7 +393,7 @@ func processAsyncResponse(client *GroupMgmtClient, body []byte) (interface{}, er
 			}
 		}
 		if len(jobId) == 0 {
-			return nil, fmt.Errorf("http response error: status (202), but no job ID returned, messages: %v",errResp)
+			return nil, fmt.Errorf("http response error: status (202), but no job ID returned, messages: %v", errResp)
 		}
 
 		id, err := waitForJobResult(jobId, client)

--- a/pkg/client/ldap_domains_object_set.go
+++ b/pkg/client/ldap_domains_object_set.go
@@ -1,0 +1,157 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Manages the storage array's membership with LDAP servers.
+const (
+	ldapDomainPath = "ldap_domains"
+)
+
+// LdapDomainObjectSet
+type LdapDomainObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new LdapDomain object
+func (objectSet *LdapDomainObjectSet) CreateObject(payload *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Post(ldapDomainPath, payload, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// UpdateObject Modify existing LdapDomain object
+func (objectSet *LdapDomainObjectSet) UpdateObject(id string, payload *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Put(ldapDomainPath, id, payload, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// DeleteObject deletes the LdapDomain object with the specified ID
+func (objectSet *LdapDomainObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(ldapDomainPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a LdapDomain object with the given ID
+func (objectSet *LdapDomainObjectSet) GetObject(id string) (*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.Get(ldapDomainPath, id, &nimbleos.LdapDomain{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.LdapDomain), err
+}
+
+// GetObjectList returns the list of LdapDomain objects
+func (objectSet *LdapDomainObjectSet) GetObjectList() ([]*nimbleos.LdapDomain, error) {
+	resp, err := objectSet.Client.List(ldapDomainPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildLdapDomainObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of LdapDomain objects using the given params query info
+func (objectSet *LdapDomainObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.LdapDomain, error) {
+	ldapDomainObjectSetResp, err := objectSet.Client.ListFromParams(ldapDomainPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildLdapDomainObjectSet(ldapDomainObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildLdapDomainObjectSet(response interface{}) []*nimbleos.LdapDomain {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.LdapDomain, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.LdapDomain{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}
+
+// List of supported actions on object sets
+
+// TestUser - Tests whether the user exist in the given LDAP Domain.
+func (objectSet *LdapDomainObjectSet) TestUser(id *string, user *string) (*nimbleos.NsLdapUser, error) {
+	testUserUri := ldapDomainPath
+	testUserUri = testUserUri + "/" + *id
+	testUserUri = testUserUri + "/actions/" + "test_user"
+
+	payload := &struct {
+		Id   *string `json:"id,omitempty"`
+		User *string `json:"user,omitempty"`
+	}{
+		id,
+		user,
+	}
+
+	resp, err := objectSet.Client.Post(testUserUri, payload, &nimbleos.NsLdapUser{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.NsLdapUser), err
+}
+
+// TestGroup - Tests whether the user group exist in the given LDAP Domain.
+func (objectSet *LdapDomainObjectSet) TestGroup(id *string, group *string) error {
+	testGroupUri := ldapDomainPath
+	testGroupUri = testGroupUri + "/" + *id
+	testGroupUri = testGroupUri + "/actions/" + "test_group"
+
+	payload := &struct {
+		Id    *string `json:"id,omitempty"`
+		Group *string `json:"group,omitempty"`
+	}{
+		id,
+		group,
+	}
+
+	_, err := objectSet.Client.Post(testGroupUri, payload, &nimbleos.LdapDomain{})
+	return err
+}
+
+// ReportStatus - Reports the LDAP connectivity status of the given LDAP ID.
+func (objectSet *LdapDomainObjectSet) ReportStatus(id *string) (*nimbleos.NsLdapReportStatusReturn, error) {
+	reportStatusUri := ldapDomainPath
+	reportStatusUri = reportStatusUri + "/" + *id
+	reportStatusUri = reportStatusUri + "/actions/" + "report_status"
+
+	payload := &struct {
+		Id *string `json:"id,omitempty"`
+	}{
+		id,
+	}
+
+	resp, err := objectSet.Client.Post(reportStatusUri, payload, &nimbleos.NsLdapReportStatusReturn{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.NsLdapReportStatusReturn), err
+}

--- a/pkg/client/object_set_factory.go
+++ b/pkg/client/object_set_factory.go
@@ -2,223 +2,6 @@
 
 package client
 
-// VersionObjectSet returns a reference to the Version object set
-func (client *GroupMgmtClient) GetVersionObjectSet() *VersionObjectSet {
-	return &VersionObjectSet{
-		Client: client,
-	}
-}
-
-// ApplicationCategoryObjectSet returns a reference to the ApplicationCategory object set
-func (client *GroupMgmtClient) GetApplicationCategoryObjectSet() *ApplicationCategoryObjectSet {
-	return &ApplicationCategoryObjectSet{
-		Client: client,
-	}
-}
-
-// ChapUserObjectSet returns a reference to the ChapUser object set
-func (client *GroupMgmtClient) GetChapUserObjectSet() *ChapUserObjectSet {
-	return &ChapUserObjectSet{
-		Client: client,
-	}
-}
-
-// MasterKeyObjectSet returns a reference to the MasterKey object set
-func (client *GroupMgmtClient) GetMasterKeyObjectSet() *MasterKeyObjectSet {
-	return &MasterKeyObjectSet{
-		Client: client,
-	}
-}
-
-// AlarmObjectSet returns a reference to the Alarm object set
-func (client *GroupMgmtClient) GetAlarmObjectSet() *AlarmObjectSet {
-	return &AlarmObjectSet{
-		Client: client,
-	}
-}
-
-// VolumeObjectSet returns a reference to the Volume object set
-func (client *GroupMgmtClient) GetVolumeObjectSet() *VolumeObjectSet {
-	return &VolumeObjectSet{
-		Client: client,
-	}
-}
-
-// ShelfObjectSet returns a reference to the Shelf object set
-func (client *GroupMgmtClient) GetShelfObjectSet() *ShelfObjectSet {
-	return &ShelfObjectSet{
-		Client: client,
-	}
-}
-
-// KeyManagerObjectSet returns a reference to the KeyManager object set
-func (client *GroupMgmtClient) GetKeyManagerObjectSet() *KeyManagerObjectSet {
-	return &KeyManagerObjectSet{
-		Client: client,
-	}
-}
-
-// ProtectionTemplateObjectSet returns a reference to the ProtectionTemplate object set
-func (client *GroupMgmtClient) GetProtectionTemplateObjectSet() *ProtectionTemplateObjectSet {
-	return &ProtectionTemplateObjectSet{
-		Client: client,
-	}
-}
-
-// FolderObjectSet returns a reference to the Folder object set
-func (client *GroupMgmtClient) GetFolderObjectSet() *FolderObjectSet {
-	return &FolderObjectSet{
-		Client: client,
-	}
-}
-
-// TokenObjectSet returns a reference to the Token object set
-func (client *GroupMgmtClient) GetTokenObjectSet() *TokenObjectSet {
-	return &TokenObjectSet{
-		Client: client,
-	}
-}
-
-// FibreChannelInterfaceObjectSet returns a reference to the FibreChannelInterface object set
-func (client *GroupMgmtClient) GetFibreChannelInterfaceObjectSet() *FibreChannelInterfaceObjectSet {
-	return &FibreChannelInterfaceObjectSet{
-		Client: client,
-	}
-}
-
-// NetworkInterfaceObjectSet returns a reference to the NetworkInterface object set
-func (client *GroupMgmtClient) GetNetworkInterfaceObjectSet() *NetworkInterfaceObjectSet {
-	return &NetworkInterfaceObjectSet{
-		Client: client,
-	}
-}
-
-// ArrayObjectSet returns a reference to the Array object set
-func (client *GroupMgmtClient) GetArrayObjectSet() *ArrayObjectSet {
-	return &ArrayObjectSet{
-		Client: client,
-	}
-}
-
-// FibreChannelConfigObjectSet returns a reference to the FibreChannelConfig object set
-func (client *GroupMgmtClient) GetFibreChannelConfigObjectSet() *FibreChannelConfigObjectSet {
-	return &FibreChannelConfigObjectSet{
-		Client: client,
-	}
-}
-
-// InitiatorObjectSet returns a reference to the Initiator object set
-func (client *GroupMgmtClient) GetInitiatorObjectSet() *InitiatorObjectSet {
-	return &InitiatorObjectSet{
-		Client: client,
-	}
-}
-
-// PerformancePolicyObjectSet returns a reference to the PerformancePolicy object set
-func (client *GroupMgmtClient) GetPerformancePolicyObjectSet() *PerformancePolicyObjectSet {
-	return &PerformancePolicyObjectSet{
-		Client: client,
-	}
-}
-
-// SpaceDomainObjectSet returns a reference to the SpaceDomain object set
-func (client *GroupMgmtClient) GetSpaceDomainObjectSet() *SpaceDomainObjectSet {
-	return &SpaceDomainObjectSet{
-		Client: client,
-	}
-}
-
-// SnapshotCollectionObjectSet returns a reference to the SnapshotCollection object set
-func (client *GroupMgmtClient) GetSnapshotCollectionObjectSet() *SnapshotCollectionObjectSet {
-	return &SnapshotCollectionObjectSet{
-		Client: client,
-	}
-}
-
-// ReplicationPartnerObjectSet returns a reference to the ReplicationPartner object set
-func (client *GroupMgmtClient) GetReplicationPartnerObjectSet() *ReplicationPartnerObjectSet {
-	return &ReplicationPartnerObjectSet{
-		Client: client,
-	}
-}
-
-// EventObjectSet returns a reference to the Event object set
-func (client *GroupMgmtClient) GetEventObjectSet() *EventObjectSet {
-	return &EventObjectSet{
-		Client: client,
-	}
-}
-
-// SnapshotObjectSet returns a reference to the Snapshot object set
-func (client *GroupMgmtClient) GetSnapshotObjectSet() *SnapshotObjectSet {
-	return &SnapshotObjectSet{
-		Client: client,
-	}
-}
-
-// ApplicationServerObjectSet returns a reference to the ApplicationServer object set
-func (client *GroupMgmtClient) GetApplicationServerObjectSet() *ApplicationServerObjectSet {
-	return &ApplicationServerObjectSet{
-		Client: client,
-	}
-}
-
-// UserPolicyObjectSet returns a reference to the UserPolicy object set
-func (client *GroupMgmtClient) GetUserPolicyObjectSet() *UserPolicyObjectSet {
-	return &UserPolicyObjectSet{
-		Client: client,
-	}
-}
-
-// UserGroupObjectSet returns a reference to the UserGroup object set
-func (client *GroupMgmtClient) GetUserGroupObjectSet() *UserGroupObjectSet {
-	return &UserGroupObjectSet{
-		Client: client,
-	}
-}
-
-// SubnetObjectSet returns a reference to the Subnet object set
-func (client *GroupMgmtClient) GetSubnetObjectSet() *SubnetObjectSet {
-	return &SubnetObjectSet{
-		Client: client,
-	}
-}
-
-// ControllerObjectSet returns a reference to the Controller object set
-func (client *GroupMgmtClient) GetControllerObjectSet() *ControllerObjectSet {
-	return &ControllerObjectSet{
-		Client: client,
-	}
-}
-
-// FibreChannelSessionObjectSet returns a reference to the FibreChannelSession object set
-func (client *GroupMgmtClient) GetFibreChannelSessionObjectSet() *FibreChannelSessionObjectSet {
-	return &FibreChannelSessionObjectSet{
-		Client: client,
-	}
-}
-
-// UserObjectSet returns a reference to the User object set
-func (client *GroupMgmtClient) GetUserObjectSet() *UserObjectSet {
-	return &UserObjectSet{
-		Client: client,
-	}
-}
-
-// ProtectionScheduleObjectSet returns a reference to the ProtectionSchedule object set
-func (client *GroupMgmtClient) GetProtectionScheduleObjectSet() *ProtectionScheduleObjectSet {
-	return &ProtectionScheduleObjectSet{
-		Client: client,
-	}
-}
-
-// InitiatorGroupObjectSet returns a reference to the InitiatorGroup object set
-func (client *GroupMgmtClient) GetInitiatorGroupObjectSet() *InitiatorGroupObjectSet {
-	return &InitiatorGroupObjectSet{
-		Client: client,
-	}
-}
-
 // AccessControlRecordObjectSet returns a reference to the AccessControlRecord object set
 func (client *GroupMgmtClient) GetAccessControlRecordObjectSet() *AccessControlRecordObjectSet {
 	return &AccessControlRecordObjectSet{
@@ -233,30 +16,30 @@ func (client *GroupMgmtClient) GetActiveDirectoryMembershipObjectSet() *ActiveDi
 	}
 }
 
-// FibreChannelPortObjectSet returns a reference to the FibreChannelPort object set
-func (client *GroupMgmtClient) GetFibreChannelPortObjectSet() *FibreChannelPortObjectSet {
-	return &FibreChannelPortObjectSet{
+// AlarmObjectSet returns a reference to the Alarm object set
+func (client *GroupMgmtClient) GetAlarmObjectSet() *AlarmObjectSet {
+	return &AlarmObjectSet{
 		Client: client,
 	}
 }
 
-// ProtocolEndpointObjectSet returns a reference to the ProtocolEndpoint object set
-func (client *GroupMgmtClient) GetProtocolEndpointObjectSet() *ProtocolEndpointObjectSet {
-	return &ProtocolEndpointObjectSet{
+// ApplicationCategoryObjectSet returns a reference to the ApplicationCategory object set
+func (client *GroupMgmtClient) GetApplicationCategoryObjectSet() *ApplicationCategoryObjectSet {
+	return &ApplicationCategoryObjectSet{
 		Client: client,
 	}
 }
 
-// WitnessObjectSet returns a reference to the Witness object set
-func (client *GroupMgmtClient) GetWitnessObjectSet() *WitnessObjectSet {
-	return &WitnessObjectSet{
+// ApplicationServerObjectSet returns a reference to the ApplicationServer object set
+func (client *GroupMgmtClient) GetApplicationServerObjectSet() *ApplicationServerObjectSet {
+	return &ApplicationServerObjectSet{
 		Client: client,
 	}
 }
 
-// JobObjectSet returns a reference to the Job object set
-func (client *GroupMgmtClient) GetJobObjectSet() *JobObjectSet {
-	return &JobObjectSet{
+// ArrayObjectSet returns a reference to the Array object set
+func (client *GroupMgmtClient) GetArrayObjectSet() *ArrayObjectSet {
+	return &ArrayObjectSet{
 		Client: client,
 	}
 }
@@ -268,16 +51,16 @@ func (client *GroupMgmtClient) GetAuditLogObjectSet() *AuditLogObjectSet {
 	}
 }
 
-// PoolObjectSet returns a reference to the Pool object set
-func (client *GroupMgmtClient) GetPoolObjectSet() *PoolObjectSet {
-	return &PoolObjectSet{
+// ChapUserObjectSet returns a reference to the ChapUser object set
+func (client *GroupMgmtClient) GetChapUserObjectSet() *ChapUserObjectSet {
+	return &ChapUserObjectSet{
 		Client: client,
 	}
 }
 
-// VolumeCollectionObjectSet returns a reference to the VolumeCollection object set
-func (client *GroupMgmtClient) GetVolumeCollectionObjectSet() *VolumeCollectionObjectSet {
-	return &VolumeCollectionObjectSet{
+// ControllerObjectSet returns a reference to the Controller object set
+func (client *GroupMgmtClient) GetControllerObjectSet() *ControllerObjectSet {
+	return &ControllerObjectSet{
 		Client: client,
 	}
 }
@@ -289,9 +72,51 @@ func (client *GroupMgmtClient) GetDiskObjectSet() *DiskObjectSet {
 	}
 }
 
+// EventObjectSet returns a reference to the Event object set
+func (client *GroupMgmtClient) GetEventObjectSet() *EventObjectSet {
+	return &EventObjectSet{
+		Client: client,
+	}
+}
+
+// FibreChannelConfigObjectSet returns a reference to the FibreChannelConfig object set
+func (client *GroupMgmtClient) GetFibreChannelConfigObjectSet() *FibreChannelConfigObjectSet {
+	return &FibreChannelConfigObjectSet{
+		Client: client,
+	}
+}
+
 // FibreChannelInitiatorAliasObjectSet returns a reference to the FibreChannelInitiatorAlias object set
 func (client *GroupMgmtClient) GetFibreChannelInitiatorAliasObjectSet() *FibreChannelInitiatorAliasObjectSet {
 	return &FibreChannelInitiatorAliasObjectSet{
+		Client: client,
+	}
+}
+
+// FibreChannelInterfaceObjectSet returns a reference to the FibreChannelInterface object set
+func (client *GroupMgmtClient) GetFibreChannelInterfaceObjectSet() *FibreChannelInterfaceObjectSet {
+	return &FibreChannelInterfaceObjectSet{
+		Client: client,
+	}
+}
+
+// FibreChannelPortObjectSet returns a reference to the FibreChannelPort object set
+func (client *GroupMgmtClient) GetFibreChannelPortObjectSet() *FibreChannelPortObjectSet {
+	return &FibreChannelPortObjectSet{
+		Client: client,
+	}
+}
+
+// FibreChannelSessionObjectSet returns a reference to the FibreChannelSession object set
+func (client *GroupMgmtClient) GetFibreChannelSessionObjectSet() *FibreChannelSessionObjectSet {
+	return &FibreChannelSessionObjectSet{
+		Client: client,
+	}
+}
+
+// FolderObjectSet returns a reference to the Folder object set
+func (client *GroupMgmtClient) GetFolderObjectSet() *FolderObjectSet {
+	return &FolderObjectSet{
 		Client: client,
 	}
 }
@@ -303,9 +128,44 @@ func (client *GroupMgmtClient) GetGroupObjectSet() *GroupObjectSet {
 	}
 }
 
-// SoftwareVersionObjectSet returns a reference to the SoftwareVersion object set
-func (client *GroupMgmtClient) GetSoftwareVersionObjectSet() *SoftwareVersionObjectSet {
-	return &SoftwareVersionObjectSet{
+// InitiatorGroupObjectSet returns a reference to the InitiatorGroup object set
+func (client *GroupMgmtClient) GetInitiatorGroupObjectSet() *InitiatorGroupObjectSet {
+	return &InitiatorGroupObjectSet{
+		Client: client,
+	}
+}
+
+// InitiatorObjectSet returns a reference to the Initiator object set
+func (client *GroupMgmtClient) GetInitiatorObjectSet() *InitiatorObjectSet {
+	return &InitiatorObjectSet{
+		Client: client,
+	}
+}
+
+// JobObjectSet returns a reference to the Job object set
+func (client *GroupMgmtClient) GetJobObjectSet() *JobObjectSet {
+	return &JobObjectSet{
+		Client: client,
+	}
+}
+
+// KeyManagerObjectSet returns a reference to the KeyManager object set
+func (client *GroupMgmtClient) GetKeyManagerObjectSet() *KeyManagerObjectSet {
+	return &KeyManagerObjectSet{
+		Client: client,
+	}
+}
+
+// LdapDomainObjectSet returns a reference to the LdapDomain object set
+func (client *GroupMgmtClient) GetLdapDomainObjectSet() *LdapDomainObjectSet {
+	return &LdapDomainObjectSet{
+		Client: client,
+	}
+}
+
+// MasterKeyObjectSet returns a reference to the MasterKey object set
+func (client *GroupMgmtClient) GetMasterKeyObjectSet() *MasterKeyObjectSet {
+	return &MasterKeyObjectSet{
 		Client: client,
 	}
 }
@@ -313,6 +173,167 @@ func (client *GroupMgmtClient) GetSoftwareVersionObjectSet() *SoftwareVersionObj
 // NetworkConfigObjectSet returns a reference to the NetworkConfig object set
 func (client *GroupMgmtClient) GetNetworkConfigObjectSet() *NetworkConfigObjectSet {
 	return &NetworkConfigObjectSet{
+		Client: client,
+	}
+}
+
+// NetworkInterfaceObjectSet returns a reference to the NetworkInterface object set
+func (client *GroupMgmtClient) GetNetworkInterfaceObjectSet() *NetworkInterfaceObjectSet {
+	return &NetworkInterfaceObjectSet{
+		Client: client,
+	}
+}
+
+// PerformancePolicyObjectSet returns a reference to the PerformancePolicy object set
+func (client *GroupMgmtClient) GetPerformancePolicyObjectSet() *PerformancePolicyObjectSet {
+	return &PerformancePolicyObjectSet{
+		Client: client,
+	}
+}
+
+// PoolObjectSet returns a reference to the Pool object set
+func (client *GroupMgmtClient) GetPoolObjectSet() *PoolObjectSet {
+	return &PoolObjectSet{
+		Client: client,
+	}
+}
+
+// ProtectionScheduleObjectSet returns a reference to the ProtectionSchedule object set
+func (client *GroupMgmtClient) GetProtectionScheduleObjectSet() *ProtectionScheduleObjectSet {
+	return &ProtectionScheduleObjectSet{
+		Client: client,
+	}
+}
+
+// ProtectionTemplateObjectSet returns a reference to the ProtectionTemplate object set
+func (client *GroupMgmtClient) GetProtectionTemplateObjectSet() *ProtectionTemplateObjectSet {
+	return &ProtectionTemplateObjectSet{
+		Client: client,
+	}
+}
+
+// ProtocolEndpointObjectSet returns a reference to the ProtocolEndpoint object set
+func (client *GroupMgmtClient) GetProtocolEndpointObjectSet() *ProtocolEndpointObjectSet {
+	return &ProtocolEndpointObjectSet{
+		Client: client,
+	}
+}
+
+// ReplicationPartnerObjectSet returns a reference to the ReplicationPartner object set
+func (client *GroupMgmtClient) GetReplicationPartnerObjectSet() *ReplicationPartnerObjectSet {
+	return &ReplicationPartnerObjectSet{
+		Client: client,
+	}
+}
+
+// ShelfObjectSet returns a reference to the Shelf object set
+func (client *GroupMgmtClient) GetShelfObjectSet() *ShelfObjectSet {
+	return &ShelfObjectSet{
+		Client: client,
+	}
+}
+
+// SnapshotCollectionObjectSet returns a reference to the SnapshotCollection object set
+func (client *GroupMgmtClient) GetSnapshotCollectionObjectSet() *SnapshotCollectionObjectSet {
+	return &SnapshotCollectionObjectSet{
+		Client: client,
+	}
+}
+
+// SnapshotObjectSet returns a reference to the Snapshot object set
+func (client *GroupMgmtClient) GetSnapshotObjectSet() *SnapshotObjectSet {
+	return &SnapshotObjectSet{
+		Client: client,
+	}
+}
+
+// SoftwareVersionObjectSet returns a reference to the SoftwareVersion object set
+func (client *GroupMgmtClient) GetSoftwareVersionObjectSet() *SoftwareVersionObjectSet {
+	return &SoftwareVersionObjectSet{
+		Client: client,
+	}
+}
+
+// SpaceDomainObjectSet returns a reference to the SpaceDomain object set
+func (client *GroupMgmtClient) GetSpaceDomainObjectSet() *SpaceDomainObjectSet {
+	return &SpaceDomainObjectSet{
+		Client: client,
+	}
+}
+
+// SubnetObjectSet returns a reference to the Subnet object set
+func (client *GroupMgmtClient) GetSubnetObjectSet() *SubnetObjectSet {
+	return &SubnetObjectSet{
+		Client: client,
+	}
+}
+
+// SubscriberObjectSet returns a reference to the Subscriber object set
+func (client *GroupMgmtClient) GetSubscriberObjectSet() *SubscriberObjectSet {
+	return &SubscriberObjectSet{
+		Client: client,
+	}
+}
+
+// SubscriptionObjectSet returns a reference to the Subscription object set
+func (client *GroupMgmtClient) GetSubscriptionObjectSet() *SubscriptionObjectSet {
+	return &SubscriptionObjectSet{
+		Client: client,
+	}
+}
+
+// TokenObjectSet returns a reference to the Token object set
+func (client *GroupMgmtClient) GetTokenObjectSet() *TokenObjectSet {
+	return &TokenObjectSet{
+		Client: client,
+	}
+}
+
+// UserGroupObjectSet returns a reference to the UserGroup object set
+func (client *GroupMgmtClient) GetUserGroupObjectSet() *UserGroupObjectSet {
+	return &UserGroupObjectSet{
+		Client: client,
+	}
+}
+
+// UserPolicyObjectSet returns a reference to the UserPolicy object set
+func (client *GroupMgmtClient) GetUserPolicyObjectSet() *UserPolicyObjectSet {
+	return &UserPolicyObjectSet{
+		Client: client,
+	}
+}
+
+// UserObjectSet returns a reference to the User object set
+func (client *GroupMgmtClient) GetUserObjectSet() *UserObjectSet {
+	return &UserObjectSet{
+		Client: client,
+	}
+}
+
+// VersionObjectSet returns a reference to the Version object set
+func (client *GroupMgmtClient) GetVersionObjectSet() *VersionObjectSet {
+	return &VersionObjectSet{
+		Client: client,
+	}
+}
+
+// VolumeCollectionObjectSet returns a reference to the VolumeCollection object set
+func (client *GroupMgmtClient) GetVolumeCollectionObjectSet() *VolumeCollectionObjectSet {
+	return &VolumeCollectionObjectSet{
+		Client: client,
+	}
+}
+
+// VolumeObjectSet returns a reference to the Volume object set
+func (client *GroupMgmtClient) GetVolumeObjectSet() *VolumeObjectSet {
+	return &VolumeObjectSet{
+		Client: client,
+	}
+}
+
+// WitnessObjectSet returns a reference to the Witness object set
+func (client *GroupMgmtClient) GetWitnessObjectSet() *WitnessObjectSet {
+	return &WitnessObjectSet{
 		Client: client,
 	}
 }

--- a/pkg/client/subscribers_object_set.go
+++ b/pkg/client/subscribers_object_set.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Subscribers are websocket based notification clients that can subscribe to interesting operations and events and recieve notifications whenever the subscribed to operations and
+// events happen on the array.
+const (
+	subscriberPath = "subscribers"
+)
+
+// SubscriberObjectSet
+type SubscriberObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new Subscriber object
+func (objectSet *SubscriberObjectSet) CreateObject(payload *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Post(subscriberPath, payload, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// UpdateObject Modify existing Subscriber object
+func (objectSet *SubscriberObjectSet) UpdateObject(id string, payload *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Put(subscriberPath, id, payload, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// DeleteObject deletes the Subscriber object with the specified ID
+func (objectSet *SubscriberObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(subscriberPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a Subscriber object with the given ID
+func (objectSet *SubscriberObjectSet) GetObject(id string) (*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.Get(subscriberPath, id, &nimbleos.Subscriber{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.Subscriber), err
+}
+
+// GetObjectList returns the list of Subscriber objects
+func (objectSet *SubscriberObjectSet) GetObjectList() ([]*nimbleos.Subscriber, error) {
+	resp, err := objectSet.Client.List(subscriberPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriberObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of Subscriber objects using the given params query info
+func (objectSet *SubscriberObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.Subscriber, error) {
+	subscriberObjectSetResp, err := objectSet.Client.ListFromParams(subscriberPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriberObjectSet(subscriberObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildSubscriberObjectSet(response interface{}) []*nimbleos.Subscriber {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.Subscriber, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.Subscriber{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}

--- a/pkg/client/subscriptions_object_set.go
+++ b/pkg/client/subscriptions_object_set.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package client
+
+import (
+	"github.com/hpe-storage/common-host-libs/jsonutil"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+	"reflect"
+)
+
+// Subscriptions represent the list of object types or alerts that a websocket client is interested in getting notifications for. Each subscription belongs to a single notification
+// client.
+const (
+	subscriptionPath = "subscriptions"
+)
+
+// SubscriptionObjectSet
+type SubscriptionObjectSet struct {
+	Client *GroupMgmtClient
+}
+
+// CreateObject creates a new Subscription object
+func (objectSet *SubscriptionObjectSet) CreateObject(payload *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Post(subscriptionPath, payload, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscription), err
+}
+
+// UpdateObject Modify existing Subscription object
+func (objectSet *SubscriptionObjectSet) UpdateObject(id string, payload *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Put(subscriptionPath, id, payload, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*nimbleos.Subscription), err
+}
+
+// DeleteObject deletes the Subscription object with the specified ID
+func (objectSet *SubscriptionObjectSet) DeleteObject(id string) error {
+	err := objectSet.Client.Delete(subscriptionPath, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetObject returns a Subscription object with the given ID
+func (objectSet *SubscriptionObjectSet) GetObject(id string) (*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.Get(subscriptionPath, id, &nimbleos.Subscription{})
+	if err != nil {
+		return nil, err
+	}
+
+	// null check
+	if resp == nil {
+		return nil, nil
+	}
+	return resp.(*nimbleos.Subscription), err
+}
+
+// GetObjectList returns the list of Subscription objects
+func (objectSet *SubscriptionObjectSet) GetObjectList() ([]*nimbleos.Subscription, error) {
+	resp, err := objectSet.Client.List(subscriptionPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriptionObjectSet(resp), err
+}
+
+// GetObjectListFromParams returns the list of Subscription objects using the given params query info
+func (objectSet *SubscriptionObjectSet) GetObjectListFromParams(params *param.GetParams) ([]*nimbleos.Subscription, error) {
+	subscriptionObjectSetResp, err := objectSet.Client.ListFromParams(subscriptionPath, params)
+	if err != nil {
+		return nil, err
+	}
+	return buildSubscriptionObjectSet(subscriptionObjectSetResp), err
+}
+
+// generated function to build the appropriate response types
+func buildSubscriptionObjectSet(response interface{}) []*nimbleos.Subscription {
+	values := reflect.ValueOf(response)
+	results := make([]*nimbleos.Subscription, values.Len())
+
+	for i := 0; i < values.Len(); i++ {
+		value := &nimbleos.Subscription{}
+		jsonutil.Decode(values.Index(i).Interface(), value)
+		results[i] = value
+	}
+
+	return results
+}

--- a/pkg/client/v1/nimbleos/group.go
+++ b/pkg/client/v1/nimbleos/group.go
@@ -159,6 +159,8 @@ type Group struct {
 	SyslogdServer *string `json:"syslogd_server,omitempty"`
 	// SyslogdPort - Port number for syslogd server.
 	SyslogdPort *int64 `json:"syslogd_port,omitempty"`
+	// SyslogdServers - Hostname and/or port of the syslogd servers.
+	SyslogdServers []*NsFqdnOrIpAndPortObject `json:"syslogd_servers,omitempty"`
 	// VvolEnabled - Are vvols enabled on this group.
 	VvolEnabled *bool `json:"vvol_enabled,omitempty"`
 	// IscsiEnabled - Whether iSCSI is enabled on this group.

--- a/pkg/client/v1/nimbleos/ns_error.go
+++ b/pkg/client/v1/nimbleos/ns_error.go
@@ -7,12 +7,13 @@ type NsError string
 
 const (
 	cNsErrorSmReplVolcollDeletion                         NsError = "SM_repl_volcoll_deletion"
-	cNsErrorSmEncryptionGroupCipherOverride               NsError = "SM_encryption_group_cipher_override"
 	cNsErrorSmEncryptionMustBeEnabled                     NsError = "SM_encryption_must_be_enabled"
+	cNsErrorSmEncryptionGroupCipherOverride               NsError = "SM_encryption_group_cipher_override"
 	cNsErrorSmExtTrigSchedNotPresent                      NsError = "SM_ext_trig_sched_not_present"
 	cNsErrorSmAppserverNotFound                           NsError = "SM_appserver_not_found"
 	cNsErrorSmFolderReplPartner                           NsError = "SM_folder_repl_partner"
 	cNsErrorSmArrayPoolMember                             NsError = "SM_array_pool_member"
+	cNsErrorSmErrInvalidArg                               NsError = "SM_err_invalid_arg"
 	cNsErrorSmErrShelfCreateRfail                         NsError = "SM_err_shelf_create_rfail"
 	cNsErrorSmStarterVolCreate                            NsError = "SM_starter_vol_create"
 	cNsErrorSmInvalidNetconfigName                        NsError = "SM_invalid_netconfig_name"
@@ -35,11 +36,12 @@ const (
 	cNsErrorSmSrepDownstreamIsUpstream                    NsError = "SM_srep_downstream_is_upstream"
 	cNsErrorSmKeymgrLeave                                 NsError = "SM_keymgr_leave"
 	cNsErrorSmVolmvVolEinprog                             NsError = "SM_volmv_vol_einprog"
-	cNsErrorSmSrepNameConflictVol                         NsError = "SM_srep_name_conflict_vol"
 	cNsErrorSmMultiArrayWithoutAutomaticConnectionMethod  NsError = "SM_multi_array_without_automatic_connection_method"
+	cNsErrorSmSrepNameConflictVol                         NsError = "SM_srep_name_conflict_vol"
 	cNsErrorSmFolderUsageLimitOverPoolCapacity            NsError = "SM_folder_usage_limit_over_pool_capacity"
 	cNsErrorSmEnomem                                      NsError = "SM_enomem"
 	cNsErrorSmErrShelfNotInuse                            NsError = "SM_err_shelf_not_inuse"
+	cNsErrorSmErrLdapAdConflict                           NsError = "SM_err_ldap_ad_conflict"
 	cNsErrorSmErrShelfPreactivationMfrErr                 NsError = "SM_err_shelf_preactivation_mfr_err"
 	cNsErrorSmUpdateBusy                                  NsError = "SM_update_busy"
 	cNsErrorSmProtpolInvalidAppSync                       NsError = "SM_protpol_invalid_app_sync"
@@ -49,15 +51,16 @@ const (
 	cNsErrorSmMissingCriteriaParam                        NsError = "SM_missing_criteria_param"
 	cNsErrorSmNoPathFound                                 NsError = "SM_no_path_found"
 	cNsErrorSmIncompatibleAppCategory                     NsError = "SM_incompatible_app_category"
-	cNsErrorSmVolmvAbortEnomove                           NsError = "SM_volmv_abort_enomove"
 	cNsErrorSmLimitSnapRetentionVolcoll                   NsError = "SM_limit_snap_retention_volcoll"
+	cNsErrorSmVolmvAbortEnomove                           NsError = "SM_volmv_abort_enomove"
 	cNsErrorSmKeymgrRemove                                NsError = "SM_keymgr_remove"
 	cNsErrorSmArrayNotReachable                           NsError = "SM_array_not_reachable"
 	cNsErrorSmErrGroupMergeEventsPending                  NsError = "SM_err_group_merge_events_pending"
 	cNsErrorSmSrepNameConflictVols                        NsError = "SM_srep_name_conflict_vols"
+	cNsErrorSmErrLdapAlreadyExists                        NsError = "SM_err_ldap_already_exists"
 	cNsErrorSmPoolPartnerResumeUnsup                      NsError = "SM_pool_partner_resume_unsup"
-	cNsErrorSmArrayNotFound                               NsError = "SM_array_not_found"
 	cNsErrorSmNoIscsiHardware                             NsError = "SM_no_iscsi_hardware"
+	cNsErrorSmArrayNotFound                               NsError = "SM_array_not_found"
 	cNsErrorSmEnospc                                      NsError = "SM_enospc"
 	cNsErrorSmReservedPerfpolName                         NsError = "SM_reserved_perfpol_name"
 	cNsErrorSmInvalidRoute                                NsError = "SM_invalid_route"
@@ -71,8 +74,8 @@ const (
 	cNsErrorSmSnapshotOffline                             NsError = "SM_snapshot_offline"
 	cNsErrorSmDefaultGatewayNotInMgmtSubnet               NsError = "SM_default_gateway_not_in_mgmt_subnet"
 	cNsErrorSmErrPassphraseAuth                           NsError = "SM_err_passphrase_auth"
-	cNsErrorSmReplEexist                                  NsError = "SM_repl_eexist"
 	cNsErrorSmDisableLastProtocol                         NsError = "SM_disable_last_protocol"
+	cNsErrorSmReplEexist                                  NsError = "SM_repl_eexist"
 	cNsErrorSmSecondUntaggedAssignment                    NsError = "SM_second_untagged_assignment"
 	cNsErrorSmPoolHasPe                                   NsError = "SM_pool_has_pe"
 	cNsErrorSmErrShelfInvalidCount                        NsError = "SM_err_shelf_invalid_count"
@@ -88,8 +91,8 @@ const (
 	cNsErrorSmErrPoolStillMerging                         NsError = "SM_err_pool_still_merging"
 	cNsErrorSmFolderPerfpolAgentType                      NsError = "SM_folder_perfpol_agent_type"
 	cNsErrorSmEinval                                      NsError = "SM_einval"
-	cNsErrorSmNoAssocVols                                 NsError = "SM_no_assoc_vols"
 	cNsErrorSmShelfNotInuse                               NsError = "SM_shelf_not_inuse"
+	cNsErrorSmNoAssocVols                                 NsError = "SM_no_assoc_vols"
 	cNsErrorSmErrProtpolSettingsNotAllowed                NsError = "SM_err_protpol_settings_not_allowed"
 	cNsErrorSmFcRegenerate                                NsError = "SM_fc_regenerate"
 	cNsErrorSmErrMultiArrayGroup                          NsError = "SM_err_multi_array_group"
@@ -102,8 +105,8 @@ const (
 	cNsErrorSmUsageUnavaiable                             NsError = "SM_usage_unavaiable"
 	cNsErrorSmEconnrefused                                NsError = "SM_econnrefused"
 	cNsErrorSmReplRenameNotsup                            NsError = "SM_repl_rename_notsup"
-	cNsErrorSmSessionCreate                               NsError = "SM_session_create"
 	cNsErrorSmConflictingAclVol                           NsError = "SM_conflicting_acl_vol"
+	cNsErrorSmSessionCreate                               NsError = "SM_session_create"
 	cNsErrorSmNospace                                     NsError = "SM_nospace"
 	cNsErrorSmReservedVolcollName                         NsError = "SM_reserved_volcoll_name"
 	cNsErrorSmPoolHasFolder                               NsError = "SM_pool_has_folder"
@@ -118,8 +121,8 @@ const (
 	cNsErrorSmErrShelfDedupeBelowFdr                      NsError = "SM_err_shelf_dedupe_below_fdr"
 	cNsErrorSmErrShelfInvalidAfsCount                     NsError = "SM_err_shelf_invalid_afs_count"
 	cNsErrorSmSerialNotAvail                              NsError = "SM_serial_not_avail"
-	cNsErrorSmErrShelfSesMshipErr                         NsError = "SM_err_shelf_ses_mship_err"
 	cNsErrorSmFolderProvisionedLimitBelowCurrentUsage     NsError = "SM_folder_provisioned_limit_below_current_usage"
+	cNsErrorSmErrShelfSesMshipErr                         NsError = "SM_err_shelf_ses_mship_err"
 	cNsErrorSmPeMultiProtocolAccessNotSupported           NsError = "SM_pe_multi_protocol_access_not_supported"
 	cNsErrorSmLimitHretSnapRetentionPool                  NsError = "SM_limit_hret_snap_retention_pool"
 	cNsErrorSmPeConflictingAcl                            NsError = "SM_pe_conflicting_acl"
@@ -127,13 +130,13 @@ const (
 	cNsErrorSmErrEncryptionMasterKeyMissing               NsError = "SM_err_encryption_master_key_missing"
 	cNsErrorSmProtpolInvalidDomainName                    NsError = "SM_protpol_invalid_domain_name"
 	cNsErrorSmTooMany                                     NsError = "SM_too_many"
-	cNsErrorSmErrShelfExprRevIncompatible                 NsError = "SM_err_shelf_expr_rev_incompatible"
 	cNsErrorSmSrvUnreachable                              NsError = "SM_srv_unreachable"
 	cNsErrorSmVolumeConflict                              NsError = "SM_volume_conflict"
+	cNsErrorSmErrShelfExprRevIncompatible                 NsError = "SM_err_shelf_expr_rev_incompatible"
 	cNsErrorSmInvalidArrayName                            NsError = "SM_invalid_array_name"
 	cNsErrorSmCannotReadObject                            NsError = "SM_cannot_read_object"
-	cNsErrorSmReservedVolName                             NsError = "SM_reserved_vol_name"
 	cNsErrorSmPoolPartnerInUse                            NsError = "SM_pool_partner_in_use"
+	cNsErrorSmReservedVolName                             NsError = "SM_reserved_vol_name"
 	cNsErrorSmInvalidInitiatorgrpName                     NsError = "SM_invalid_initiatorgrp_name"
 	cNsErrorSmAsupValidateError                           NsError = "SM_asup_validate_error"
 	cNsErrorSmVersionName                                 NsError = "SM_version_name"
@@ -151,13 +154,14 @@ const (
 	cNsErrorSmInvalidNetconfigToDelete                    NsError = "SM_invalid_netconfig_to_delete"
 	cNsErrorSmErrUnknown                                  NsError = "SM_err_unknown"
 	cNsErrorSmMissingCriteriaOperator                     NsError = "SM_missing_criteria_operator"
-	cNsErrorSmInvalidAppUuid                              NsError = "SM_invalid_app_uuid"
 	cNsErrorSmArrayMemberOrphanWithArgs                   NsError = "SM_array_member_orphan_with_args"
-	cNsErrorSmEmptyVol                                    NsError = "SM_empty_vol"
+	cNsErrorSmInvalidAppUuid                              NsError = "SM_invalid_app_uuid"
 	cNsErrorSmDuplicateSubnetLabel                        NsError = "SM_duplicate_subnet_label"
 	cNsErrorSmZeroVlanIdForTaggedAssignment               NsError = "SM_zero_vlan_id_for_tagged_assignment"
+	cNsErrorSmEmptyVol                                    NsError = "SM_empty_vol"
 	cNsErrorSmNoActionFound                               NsError = "SM_no_action_found"
 	cNsErrorSmSyncReplUnconfigureInProgress               NsError = "SM_sync_repl_unconfigure_in_progress"
+	cNsErrorSmErrMissingArg                               NsError = "SM_err_missing_arg"
 	cNsErrorSmVolThickProvMoveInvalid                     NsError = "SM_vol_thick_prov_move_invalid"
 	cNsErrorSmMissingAdvancedCriteriaConstructor          NsError = "SM_missing_advanced_criteria_constructor"
 	cNsErrorSmPoolUnknown                                 NsError = "SM_pool_unknown"
@@ -166,18 +170,18 @@ const (
 	cNsErrorSmNetconfigUpdateMismatch                     NsError = "SM_netconfig_update_mismatch"
 	cNsErrorSmSrepDownstreamVolsAcl                       NsError = "SM_srep_downstream_vols_acl"
 	cNsErrorSmStatsFrequencyInvalid                       NsError = "SM_stats_frequency_invalid"
-	cNsErrorSmDdupFolderMerge                             NsError = "SM_ddup_folder_merge"
 	cNsErrorSmInvalidSubnet                               NsError = "SM_invalid_subnet"
+	cNsErrorSmDdupFolderMerge                             NsError = "SM_ddup_folder_merge"
 	cNsErrorSmReplEnabled                                 NsError = "SM_repl_enabled"
-	cNsErrorSmPoolPartnerNameConflict                     NsError = "SM_pool_partner_name_conflict"
 	cNsErrorSmAsupPingfromMgmtipError                     NsError = "SM_asup_pingfrom_mgmtip_error"
 	cNsErrorSmEncryptionGroupScopeOverride                NsError = "SM_encryption_group_scope_override"
+	cNsErrorSmPoolPartnerNameConflict                     NsError = "SM_pool_partner_name_conflict"
 	cNsErrorSmErrMaxSessionsReached                       NsError = "SM_err_max_sessions_reached"
 	cNsErrorSmErrReplMultiplePartners                     NsError = "SM_err_repl_multiple_partners"
 	cNsErrorSmStatsNoSensors                              NsError = "SM_stats_no_sensors"
 	cNsErrorSmFolderNeedsLimit                            NsError = "SM_folder_needs_limit"
-	cNsErrorSmVolmvVvol                                   NsError = "SM_volmv_vvol"
 	cNsErrorSmErrGroupMergeInprogress                     NsError = "SM_err_group_merge_inprogress"
+	cNsErrorSmVolmvVvol                                   NsError = "SM_volmv_vvol"
 	cNsErrorSmFolderNotFound                              NsError = "SM_folder_not_found"
 	cNsErrorSmRouteExists                                 NsError = "SM_route_exists"
 	cNsErrorSmInvalidDiscoveryIp                          NsError = "SM_invalid_discovery_ip"
@@ -191,28 +195,28 @@ const (
 	cNsErrorSmNoAction                                    NsError = "SM_no_action"
 	cNsErrorSmProtpolAppSyncOracleParams                  NsError = "SM_protpol_app_sync_oracle_params"
 	cNsErrorSmProtpolInvalidVssSettings                   NsError = "SM_protpol_invalid_vss_settings"
+	cNsErrorSmShelfRaidDegraded                           NsError = "SM_shelf_raid_degraded"
 	cNsErrorSmEncryptionInvalidScope                      NsError = "SM_encryption_invalid_scope"
 	cNsErrorSmLimitSnapcollVolcoll                        NsError = "SM_limit_snapcoll_volcoll"
-	cNsErrorSmShelfRaidDegraded                           NsError = "SM_shelf_raid_degraded"
 	cNsErrorSmInvalidNonIscsiDataSubnetType               NsError = "SM_invalid_non_iscsi_data_subnet_type"
 	cNsErrorSmVolmvIncompatibleAgentType                  NsError = "SM_volmv_incompatible_agent_type"
-	cNsErrorSmReplPartnerVersionUnknown                   NsError = "SM_repl_partner_version_unknown"
 	cNsErrorSmAsupNameresError                            NsError = "SM_asup_nameres_error"
+	cNsErrorSmReplPartnerVersionUnknown                   NsError = "SM_repl_partner_version_unknown"
 	cNsErrorSmReplApiUnsup                                NsError = "SM_repl_api_unsup"
 	cNsErrorSmEperm                                       NsError = "SM_eperm"
 	cNsErrorSmEnoentEnoent                                NsError = "SM_enoent,ENOENT"
 	cNsErrorSmArrayGroupLeader                            NsError = "SM_array_group_leader"
 	cNsErrorSmInvalidInitiatorIqn                         NsError = "SM_invalid_initiator_iqn"
 	cNsErrorSmReplIntragroup                              NsError = "SM_repl_intragroup"
-	cNsErrorSmRemoveNonemptyFolder                        NsError = "SM_remove_nonempty_folder"
 	cNsErrorSmAddNoniscsiToIscsiGroup                     NsError = "SM_add_noniscsi_to_iscsi_group"
-	cNsErrorSmPoolDedupeIncapable                         NsError = "SM_pool_dedupe_incapable"
+	cNsErrorSmRemoveNonemptyFolder                        NsError = "SM_remove_nonempty_folder"
 	cNsErrorSmNoVvolSupport                               NsError = "SM_no_vvol_support"
+	cNsErrorSmPoolDedupeIncapable                         NsError = "SM_pool_dedupe_incapable"
 	cNsErrorSmNoInitiatorgrp                              NsError = "SM_no_initiatorgrp"
 	cNsErrorSmInvalidNetmask                              NsError = "SM_invalid_netmask"
 	cNsErrorSmNoDiscoveryIpInManualMode                   NsError = "SM_no_discovery_ip_in_manual_mode"
-	cNsErrorSmInvalidVolReserveValues                     NsError = "SM_invalid_vol_reserve_values"
 	cNsErrorSmSupportIpInvalid                            NsError = "SM_support_ip_invalid"
+	cNsErrorSmInvalidVolReserveValues                     NsError = "SM_invalid_vol_reserve_values"
 	cNsErrorSmErrShelfForeignDisk                         NsError = "SM_err_shelf_foreign_disk"
 	cNsErrorSmVolsnapAlreadyExported                      NsError = "SM_volsnap_already_exported"
 	cNsErrorSmFcInitiatorgrpSubnetNotSupported            NsError = "SM_fc_initiatorgrp_subnet_not_supported"
@@ -237,17 +241,18 @@ const (
 	cNsErrorSmFolderLimitInval                            NsError = "SM_folder_limit_inval"
 	cNsErrorSmShelfSsdDegraded                            NsError = "SM_shelf_ssd_degraded"
 	cNsErrorSmFolderOverdraftLimitNeedsUsageLimit         NsError = "SM_folder_overdraft_limit_needs_usage_limit"
-	cNsErrorSmEncryptionMasterKeyMissing                  NsError = "SM_encryption_master_key_missing"
 	cNsErrorSmSrepAgentTypeMismatchDownstreamVols         NsError = "SM_srep_agent_type_mismatch_downstream_vols"
+	cNsErrorSmEncryptionMasterKeyMissing                  NsError = "SM_encryption_master_key_missing"
 	cNsErrorSmErrVolNotOfflineOnRestore                   NsError = "SM_err_vol_not_offline_on_restore"
 	cNsErrorSmReplHandoverBusy                            NsError = "SM_repl_handover_busy"
 	cNsErrorSmNotOwner                                    NsError = "SM_not_owner"
 	cNsErrorSmSrepDownstreamAcl                           NsError = "SM_srep_downstream_acl"
 	cNsErrorSmNoSubnetWithLabel                           NsError = "SM_no_subnet_with_label"
 	cNsErrorSmPoolUpdateInvalArrays                       NsError = "SM_pool_update_inval_arrays"
-	cNsErrorSmVolHasOnlineSnap                            NsError = "SM_vol_has_online_snap"
 	cNsErrorSmInvalidDataIp                               NsError = "SM_invalid_data_ip"
+	cNsErrorSmVolHasOnlineSnap                            NsError = "SM_vol_has_online_snap"
 	cNsErrorSmPoolVolmvEinprog                            NsError = "SM_pool_volmv_einprog"
+	cNsErrorSmErrLdapBindPasswordNoUser                   NsError = "SM_err_ldap_bind_password_no_user"
 	cNsErrorSmNoDataIpOnMgmtPlusData                      NsError = "SM_no_data_ip_on_mgmt_plus_data"
 	cNsErrorSmConflictingAclLun                           NsError = "SM_conflicting_acl_lun"
 	cNsErrorSmVpCreatedIgrp                               NsError = "SM_vp_created_igrp"
@@ -255,35 +260,35 @@ const (
 	cNsErrorSmBadPkg                                      NsError = "SM_bad_pkg"
 	cNsErrorSmPasswdSameAsCurrent                         NsError = "SM_passwd_same_as_current"
 	cNsErrorSmSnaplunsOutOfSync                           NsError = "SM_snapluns_out_of_sync"
-	cNsErrorSmLimitSnapPool                               NsError = "SM_limit_snap_pool"
 	cNsErrorSmMultiProtocolAccessNotSupported             NsError = "SM_multi_protocol_access_not_supported"
+	cNsErrorSmLimitSnapPool                               NsError = "SM_limit_snap_pool"
 	cNsErrorSmVolHasClone                                 NsError = "SM_vol_has_clone"
 	cNsErrorSmDedupeSingleArray                           NsError = "SM_dedupe_single_array"
 	cNsErrorSmEncryptionMasterKeyInactive                 NsError = "SM_encryption_master_key_inactive"
 	cNsErrorSmSnapHasClone                                NsError = "SM_snap_has_clone"
 	cNsErrorSmErrEncryptionNeeded                         NsError = "SM_err_encryption_needed"
 	cNsErrorSmMismatchingDuplicateSubnet                  NsError = "SM_mismatching_duplicate_subnet"
-	cNsErrorSmSrepNotGroupScopedVol                       NsError = "SM_srep_not_group_scoped_vol"
 	cNsErrorSmOnlyVvolFolderFolset                        NsError = "SM_only_vvol_folder_folset"
+	cNsErrorSmSrepNotGroupScopedVol                       NsError = "SM_srep_not_group_scoped_vol"
 	cNsErrorSmReplSnapshotSync                            NsError = "SM_repl_snapshot_sync"
 	cNsErrorSmStatsNoSuchObject                           NsError = "SM_stats_no_such_object"
 	cNsErrorSmDefaultRouteMissing                         NsError = "SM_default_route_missing"
-	cNsErrorSmReplVasa3ApiUnsup                           NsError = "SM_repl_vasa3_api_unsup"
 	cNsErrorSmOverlappingSubnets                          NsError = "SM_overlapping_subnets"
+	cNsErrorSmReplVasa3ApiUnsup                           NsError = "SM_repl_vasa3_api_unsup"
 	cNsErrorSmMissingArg                                  NsError = "SM_missing_arg"
-	cNsErrorSmVolmvCachePinDedupeNotsupp                  NsError = "SM_volmv_cache_pin_dedupe_notsupp"
 	cNsErrorSmErrMergeConflict                            NsError = "SM_err_merge_conflict"
+	cNsErrorSmVolmvCachePinDedupeNotsupp                  NsError = "SM_volmv_cache_pin_dedupe_notsupp"
 	cNsErrorSmTooSmall                                    NsError = "SM_too_small"
 	cNsErrorSmVolWarnGreaterThanLimit                     NsError = "SM_vol_warn_greater_than_limit"
 	cNsErrorSmKeymgrUnreach                               NsError = "SM_keymgr_unreach"
 	cNsErrorSmErrFcAsymmetryNotSupported                  NsError = "SM_err_fc_asymmetry_not_supported"
 	cNsErrorSmLunMismatch                                 NsError = "SM_lun_mismatch"
-	cNsErrorSmErrShelfInvalidDiskCount                    NsError = "SM_err_shelf_invalid_disk_count"
 	cNsErrorSmLimitVolacl                                 NsError = "SM_limit_volacl"
+	cNsErrorSmErrShelfInvalidDiskCount                    NsError = "SM_err_shelf_invalid_disk_count"
 	cNsErrorSmControllerNotActive                         NsError = "SM_controller_not_active"
 	cNsErrorSmReplNoPartnerAvail                          NsError = "SM_repl_no_partner_avail"
-	cNsErrorSmSreplMgmtOpDisallowedWhenSolo               NsError = "SM_srepl_mgmt_op_disallowed_when_solo"
 	cNsErrorSmNoMgmtSubnetSpecified                       NsError = "SM_no_mgmt_subnet_specified"
+	cNsErrorSmSreplMgmtOpDisallowedWhenSolo               NsError = "SM_srepl_mgmt_op_disallowed_when_solo"
 	cNsErrorSmFolderConflict                              NsError = "SM_folder_conflict"
 	cNsErrorSmInvalidDataSubnet                           NsError = "SM_invalid_data_subnet"
 	cNsErrorSmVolUsageUnavailable                         NsError = "SM_vol_usage_unavailable"
@@ -293,8 +298,8 @@ const (
 	cNsErrorSmDuplicateSubnetVlanId                       NsError = "SM_duplicate_subnet_vlan_id"
 	cNsErrorSmReplOpenstackUnsup                          NsError = "SM_repl_openstack_unsup"
 	cNsErrorSmNoAvailableLun                              NsError = "SM_no_available_lun"
-	cNsErrorSmGroupPartnerNameConflict                    NsError = "SM_group_partner_name_conflict"
 	cNsErrorSmMgmtIpNotOnMgmt                             NsError = "SM_mgmt_ip_not_on_mgmt"
+	cNsErrorSmGroupPartnerNameConflict                    NsError = "SM_group_partner_name_conflict"
 	cNsErrorSmInUseLun                                    NsError = "SM_in_use_lun"
 	cNsErrorSmNotFcInitiatorgrp                           NsError = "SM_not_fc_initiatorgrp"
 	cNsErrorSmErrShelfInvalidCsz                          NsError = "SM_err_shelf_invalid_csz"
@@ -302,15 +307,15 @@ const (
 	cNsErrorSmEncryptionInvalidMode                       NsError = "SM_encryption_invalid_mode"
 	cNsErrorSmAsupDisabled                                NsError = "SM_asup_disabled"
 	cNsErrorSmErrShelfConnectedOnlyOneSide                NsError = "SM_err_shelf_connected_only_one_side"
-	cNsErrorSmVolmvEnospace                               NsError = "SM_volmv_enospace"
 	cNsErrorSmIncompatibleVolumes                         NsError = "SM_incompatible_volumes"
+	cNsErrorSmVolmvEnospace                               NsError = "SM_volmv_enospace"
 	cNsErrorSmComplexTypeQueryParam                       NsError = "SM_complex_type_query_param"
 	cNsErrorSmAsupError                                   NsError = "SM_asup_error"
 	cNsErrorSmReplUnassignedAppcat                        NsError = "SM_repl_unassigned_appcat"
 	cNsErrorSmErrFcRegenerateInvalidOperationTdz          NsError = "SM_err_fc_regenerate_invalid_operation_tdz"
 	cNsErrorSmInvalidPathVariable                         NsError = "SM_invalid_path_variable"
-	cNsErrorSmErrArgChangeNotAllowed                      NsError = "SM_err_arg_change_not_allowed"
 	cNsErrorSmSpecifiedSnapshotLun                        NsError = "SM_specified_snapshot_lun"
+	cNsErrorSmErrArgChangeNotAllowed                      NsError = "SM_err_arg_change_not_allowed"
 	cNsErrorSmSrepDownstreamAssocedVol                    NsError = "SM_srep_downstream_assoced_vol"
 	cNsErrorSmLimitScopeValues                            NsError = "SM_limit_scope_values"
 	cNsErrorSmErrPassphraseInval                          NsError = "SM_err_passphrase_inval"
@@ -319,33 +324,33 @@ const (
 	cNsErrorSmNoOperationFound                            NsError = "SM_no_operation_found"
 	cNsErrorSmInvalidDataForPartnerType                   NsError = "SM_invalid_data_for_partner_type"
 	cNsErrorSmSrvUpdatePrecheck                           NsError = "SM_srv_update_precheck"
-	cNsErrorSmVolDedupeEncryptionInvalid                  NsError = "SM_vol_dedupe_encryption_invalid"
-	cNsErrorSmVvolFolderNoAppsrvr                         NsError = "SM_vvol_folder_no_appsrvr"
 	cNsErrorSmHttpConflict                                NsError = "SM_http_conflict"
+	cNsErrorSmVvolFolderNoAppsrvr                         NsError = "SM_vvol_folder_no_appsrvr"
+	cNsErrorSmVolDedupeEncryptionInvalid                  NsError = "SM_vol_dedupe_encryption_invalid"
 	cNsErrorSmArrayRenameInNetconfigFailed                NsError = "SM_array_rename_in_netconfig_failed"
 	cNsErrorSmInvalidInitiatorIp                          NsError = "SM_invalid_initiator_ip"
 	cNsErrorSmDuplicateVol                                NsError = "SM_duplicate_vol"
 	cNsErrorSmErrShelfInvalidModel                        NsError = "SM_err_shelf_invalid_model"
 	cNsErrorSmReplProtectLastSnap                         NsError = "SM_repl_protect_last_snap"
 	cNsErrorSmErrGroupMergeBusy                           NsError = "SM_err_group_merge_busy"
-	cNsErrorSmErrVolmvPoolMerging                         NsError = "SM_err_volmv_pool_merging"
 	cNsErrorSmArrayNotFoundWithArgs                       NsError = "SM_array_not_found_with_args"
 	cNsErrorSmConnectionRebalancingWithoutAutomaticMethod NsError = "SM_connection_rebalancing_without_automatic_method"
+	cNsErrorSmErrVolmvPoolMerging                         NsError = "SM_err_volmv_pool_merging"
 	cNsErrorSmSrepDownstreamNoCommonSnapVols              NsError = "SM_srep_downstream_no_common_snap_vols"
-	cNsErrorSmErrShelfWrongSasPort                        NsError = "SM_err_shelf_wrong_sas_port"
 	cNsErrorSmFolderUsageLimitBelowCurrentUsage           NsError = "SM_folder_usage_limit_below_current_usage"
+	cNsErrorSmErrShelfWrongSasPort                        NsError = "SM_err_shelf_wrong_sas_port"
 	cNsErrorSmLimitSnapRetentionPool                      NsError = "SM_limit_snap_retention_pool"
+	cNsErrorSmSrepNotGroupScopedVols                      NsError = "SM_srep_not_group_scoped_vols"
 	cNsErrorSmErrShelfExprFwVerInval                      NsError = "SM_err_shelf_expr_fw_ver_inval"
 	cNsErrorSmSrepVolcollUnsup                            NsError = "SM_srep_volcoll_unsup"
-	cNsErrorSmSrepNotGroupScopedVols                      NsError = "SM_srep_not_group_scoped_vols"
 	cNsErrorSmFcIntfNotFound                              NsError = "SM_fc_intf_not_found"
 	cNsErrorSmVolUnknown                                  NsError = "SM_vol_unknown"
 	cNsErrorSmErrShelfEbusy                               NsError = "SM_err_shelf_ebusy"
 	cNsErrorSmAppserverInUse                              NsError = "SM_appserver_in_use"
-	cNsErrorSmPoolDoesNotHaveFolder                       NsError = "SM_pool_does_not_have_folder"
 	cNsErrorSmPerfpolNotFound                             NsError = "SM_perfpol_not_found"
-	cNsErrorSmPerfpolOob                                  NsError = "SM_perfpol_oob"
 	cNsErrorSmDuplicateInitiator                          NsError = "SM_duplicate_initiator"
+	cNsErrorSmPerfpolOob                                  NsError = "SM_perfpol_oob"
+	cNsErrorSmPoolDoesNotHaveFolder                       NsError = "SM_pool_does_not_have_folder"
 	cNsErrorSmInUseAppUuid                                NsError = "SM_in_use_app_uuid"
 	cNsErrorSmPartnerCfgSync                              NsError = "SM_partner_cfg_sync"
 	cNsErrorSmNotDownloadingSw                            NsError = "SM_not_downloading_sw"
@@ -353,22 +358,22 @@ const (
 	cNsErrorSmSrepDownstreamNoCommonSnapVol               NsError = "SM_srep_downstream_no_common_snap_vol"
 	cNsErrorSmEbusy                                       NsError = "SM_ebusy"
 	cNsErrorSmErrReplCantConnect                          NsError = "SM_err_repl_cant_connect"
-	cNsErrorSmErrShelfExpanderErr                         NsError = "SM_err_shelf_expander_err"
 	cNsErrorSmPeFailAclRemoval                            NsError = "SM_pe_fail_acl_removal"
+	cNsErrorSmErrShelfExpanderErr                         NsError = "SM_err_shelf_expander_err"
 	cNsErrorSmSupportIpNotOnMgmt                          NsError = "SM_support_ip_not_on_mgmt"
 	cNsErrorSmAtLeastOneGroupSubnet                       NsError = "SM_at_least_one_group_subnet"
 	cNsErrorSmUnsupportedAccessProtocol                   NsError = "SM_unsupported_access_protocol"
 	cNsErrorSmSpaceInfoUnavail                            NsError = "SM_space_info_unavail"
 	cNsErrorSmLimitVolmvHretSnapPool                      NsError = "SM_limit_volmv_hret_snap_pool"
+	cNsErrorSmDataIpNotOnSubnet                           NsError = "SM_data_ip_not_on_subnet"
 	cNsErrorSmStartTimeBeyondEndTime                      NsError = "SM_start_time_beyond_end_time"
 	cNsErrorSmReplRemotePaused                            NsError = "SM_repl_remote_paused"
-	cNsErrorSmDataIpNotOnSubnet                           NsError = "SM_data_ip_not_on_subnet"
 	cNsErrorSmConflictingInitiatorAlias                   NsError = "SM_conflicting_initiator_alias"
 	cNsErrorSmReplEditPartnerNameNotPaused                NsError = "SM_repl_edit_partner_name_not_paused"
 	cNsErrorSmShelfForeignDisk                            NsError = "SM_shelf_foreign_disk"
 	cNsErrorSmQosLimitNotInRange                          NsError = "SM_qos_limit_not_in_range"
-	cNsErrorSmErrShelfNoRserial                           NsError = "SM_err_shelf_no_rserial"
 	cNsErrorSmUntaggedMtuNotLargest                       NsError = "SM_untagged_mtu_not_largest"
+	cNsErrorSmErrShelfNoRserial                           NsError = "SM_err_shelf_no_rserial"
 	cNsErrorSmErrShelfDisconnected                        NsError = "SM_err_shelf_disconnected"
 	cNsErrorSmSubnetAlreadyAssignedOnNic                  NsError = "SM_subnet_already_assigned_on_nic"
 	cNsErrorSmFcSessionExist                              NsError = "SM_fc_session_exist"
@@ -382,14 +387,14 @@ const (
 	cNsErrorSmErrGroupMergeDbLoad                         NsError = "SM_err_group_merge_db_load"
 	cNsErrorSmEio                                         NsError = "SM_eio"
 	cNsErrorSmSrepDownstreamOnlineVol                     NsError = "SM_srep_downstream_online_vol"
-	cNsErrorSmPoolNoSrcArray                              NsError = "SM_pool_no_src_array"
 	cNsErrorSmInvalidKeyvalue                             NsError = "SM_invalid_keyvalue"
+	cNsErrorSmPoolNoSrcArray                              NsError = "SM_pool_no_src_array"
 	cNsErrorSmProtpolMaxLength                            NsError = "SM_protpol_max_length"
 	cNsErrorSmVolAssocVolcoll                             NsError = "SM_vol_assoc_volcoll"
 	cNsErrorSmMissingDiscoveryIp                          NsError = "SM_missing_discovery_ip"
 	cNsErrorSmReplDeleteReplicaUnsup                      NsError = "SM_repl_delete_replica_unsup"
-	cNsErrorSmVolSizeDecreased                            NsError = "SM_vol_size_decreased"
 	cNsErrorSmSrepDownstreamAssocedVols                   NsError = "SM_srep_downstream_assoced_vols"
+	cNsErrorSmVolSizeDecreased                            NsError = "SM_vol_size_decreased"
 	cNsErrorSmAddNonfcToFcGroup                           NsError = "SM_add_nonfc_to_fc_group"
 	cNsErrorSmNetconfigDoesNotExist                       NsError = "SM_netconfig_does_not_exist"
 	cNsErrorSmFolderVolmvEnospace                         NsError = "SM_folder_volmv_enospace"
@@ -410,8 +415,8 @@ const (
 	cNsErrorSmInvalidVlanId                               NsError = "SM_invalid_vlan_id"
 	cNsErrorSmLimitSnaplun                                NsError = "SM_limit_snaplun"
 	cNsErrorSmIncompatibleCachePolicy                     NsError = "SM_incompatible_cache_policy"
-	cNsErrorSmVolmvAbortEnospace                          NsError = "SM_volmv_abort_enospace"
 	cNsErrorSmLimitHretSnapGroup                          NsError = "SM_limit_hret_snap_group"
+	cNsErrorSmVolmvAbortEnospace                          NsError = "SM_volmv_abort_enospace"
 	cNsErrorSmVolmvEalready                               NsError = "SM_volmv_ealready"
 	cNsErrorSmAsupPingfromCtrlrbError                     NsError = "SM_asup_pingfrom_ctrlrB_error"
 	cNsErrorSmVolDedupeUnassignedAppCategory              NsError = "SM_vol_dedupe_unassigned_app_category"
@@ -420,8 +425,8 @@ const (
 	cNsErrorSmInvalidInitiatorLabel                       NsError = "SM_invalid_initiator_label"
 	cNsErrorSmDuplicateInitiatorWithArgs                  NsError = "SM_duplicate_initiator_with_args"
 	cNsErrorSmErrShelfForeign                             NsError = "SM_err_shelf_foreign"
-	cNsErrorSmInvalidAgentType                            NsError = "SM_invalid_agent_type"
 	cNsErrorSmEinprogress                                 NsError = "SM_einprogress"
+	cNsErrorSmInvalidAgentType                            NsError = "SM_invalid_agent_type"
 	cNsErrorSmNotEnoughCache                              NsError = "SM_not_enough_cache"
 	cNsErrorSmEexist                                      NsError = "SM_eexist"
 	cNsErrorSmMissingArrayNetconfig                       NsError = "SM_missing_array_netconfig"
@@ -437,9 +442,9 @@ const (
 	cNsErrorSmReplAgentTypeUnsup                          NsError = "SM_repl_agent_type_unsup"
 	cNsErrorSmReplFanoutMaximumPartnersExceeded           NsError = "SM_repl_fanout_maximum_partners_exceeded"
 	cNsErrorSmAsupPingfromCtrlraError                     NsError = "SM_asup_pingfrom_ctrlrA_error"
+	cNsErrorSmSyncReplConfigure                           NsError = "SM_sync_repl_configure"
 	cNsErrorSmErrShelfInvalidLoc                          NsError = "SM_err_shelf_invalid_loc"
 	cNsErrorSmErrShelfSsdDegraded                         NsError = "SM_err_shelf_ssd_degraded"
-	cNsErrorSmSyncReplConfigure                           NsError = "SM_sync_repl_configure"
 	cNsErrorSmAsupHeartbeatError                          NsError = "SM_asup_heartbeat_error"
 	cNsErrorSmLimitHretSnapRetentionPoolWarn              NsError = "SM_limit_hret_snap_retention_pool_warn"
 	cNsErrorSmErrAuth                                     NsError = "SM_err_auth"
@@ -449,10 +454,10 @@ const (
 	cNsErrorSmErrPoolHasGroupPartners                     NsError = "SM_err_pool_has_group_partners"
 	cNsErrorSmProtpolNotSpecified                         NsError = "SM_protpol_not_specified"
 	cNsErrorSmUnexpectedQueryParam                        NsError = "SM_unexpected_query_param"
-	cNsErrorSmVolmvAbortEalready                          NsError = "SM_volmv_abort_ealready"
 	cNsErrorSmFcIntfAlreadyInState                        NsError = "SM_fc_intf_already_in_state"
-	cNsErrorSmLimitHretSnapPool                           NsError = "SM_limit_hret_snap_pool"
 	cNsErrorSmIpUpdateNoForce                             NsError = "SM_ip_update_no_force"
+	cNsErrorSmLimitHretSnapPool                           NsError = "SM_limit_hret_snap_pool"
+	cNsErrorSmVolmvAbortEalready                          NsError = "SM_volmv_abort_ealready"
 	cNsErrorSmSrepAgentTypeMismatchDownstreamVol          NsError = "SM_srep_agent_type_mismatch_downstream_vol"
 	cNsErrorSmVssValidationTimedout                       NsError = "SM_vss_validation_timedout"
 	cNsErrorSmConfigSyncInprogress                        NsError = "SM_config_sync_inprogress"
@@ -469,8 +474,8 @@ const (
 	cNsErrorSmInvalidVolAssoc                             NsError = "SM_invalid_vol_assoc"
 	cNsErrorSmReplObjectBusy                              NsError = "SM_repl_object_busy"
 	cNsErrorSmVolcollOwner                                NsError = "SM_volcoll_owner"
-	cNsErrorSmReservedUsername                            NsError = "SM_reserved_username"
 	cNsErrorSmVvolsnapOnline                              NsError = "SM_vvolsnap_online"
+	cNsErrorSmReservedUsername                            NsError = "SM_reserved_username"
 	cNsErrorSmFolderVolmvEinprog                          NsError = "SM_folder_volmv_einprog"
 	cNsErrorSmUnexpectedObjectSetQuery                    NsError = "SM_unexpected_object_set_query"
 	cNsErrorSmProtpolInvalidValue                         NsError = "SM_protpol_invalid_value"
@@ -481,6 +486,7 @@ const (
 	cNsErrorSmInvalidFolder                               NsError = "SM_invalid_folder"
 	cNsErrorSmSrvUpdatePrecheckArray                      NsError = "SM_srv_update_precheck_array"
 	cNsErrorSmGatewayNotInSubnets                         NsError = "SM_gateway_not_in_subnets"
+	cNsErrorSmErrLdapBindUserNoPassword                   NsError = "SM_err_ldap_bind_user_no_password"
 	cNsErrorSmDeprecatedPerfpol                           NsError = "SM_deprecated_perfpol"
 	cNsErrorSmTakeoverSplitBrain                          NsError = "SM_takeover_split_brain"
 	cNsErrorSmPeIgroupProtocolMismatched                  NsError = "SM_pe_igroup_protocol_mismatched"
@@ -494,8 +500,8 @@ const (
 	cNsErrorSmSrvUnreach                                  NsError = "SM_srv_unreach"
 	cNsErrorSmPoolPartnerPauseUnsup                       NsError = "SM_pool_partner_pause_unsup"
 	cNsErrorSmNetconfigCreateDraftOnly                    NsError = "SM_netconfig_create_draft_only"
-	cNsErrorSmErrArrayNotFound                            NsError = "SM_err_array_not_found"
 	cNsErrorSmFolsetInUse                                 NsError = "SM_folset_in_use"
+	cNsErrorSmErrArrayNotFound                            NsError = "SM_err_array_not_found"
 	cNsErrorSmErrShelfSesDeviceNotReady                   NsError = "SM_err_shelf_ses_device_not_ready"
 	cNsErrorSmInvalidIp                                   NsError = "SM_invalid_ip"
 	cNsErrorSmEalready                                    NsError = "SM_ealready"
@@ -507,18 +513,19 @@ const (
 	cNsErrorSmVfVolCachePinned                            NsError = "SM_vf_vol_cache_pinned"
 	cNsErrorSmAtLeastOneIscsiCluster                      NsError = "SM_at_least_one_iscsi_cluster"
 	cNsErrorSmErrTooMany                                  NsError = "SM_err_too_many"
-	cNsErrorSmErrShelfExprMfgVerInval                     NsError = "SM_err_shelf_expr_mfg_ver_inval"
 	cNsErrorSmMgmtIpInvalid                               NsError = "SM_mgmt_ip_invalid"
+	cNsErrorSmErrShelfExprMfgVerInval                     NsError = "SM_err_shelf_expr_mfg_ver_inval"
 	cNsErrorSmErrShelfWrongCtrlrSide                      NsError = "SM_err_shelf_wrong_ctrlr_side"
 )
 
 var pNsErrorSmReplVolcollDeletion NsError
-var pNsErrorSmEncryptionGroupCipherOverride NsError
 var pNsErrorSmEncryptionMustBeEnabled NsError
+var pNsErrorSmEncryptionGroupCipherOverride NsError
 var pNsErrorSmExtTrigSchedNotPresent NsError
 var pNsErrorSmAppserverNotFound NsError
 var pNsErrorSmFolderReplPartner NsError
 var pNsErrorSmArrayPoolMember NsError
+var pNsErrorSmErrInvalidArg NsError
 var pNsErrorSmErrShelfCreateRfail NsError
 var pNsErrorSmStarterVolCreate NsError
 var pNsErrorSmInvalidNetconfigName NsError
@@ -541,11 +548,12 @@ var pNsErrorSmInvalidFcConfig NsError
 var pNsErrorSmSrepDownstreamIsUpstream NsError
 var pNsErrorSmKeymgrLeave NsError
 var pNsErrorSmVolmvVolEinprog NsError
-var pNsErrorSmSrepNameConflictVol NsError
 var pNsErrorSmMultiArrayWithoutAutomaticConnectionMethod NsError
+var pNsErrorSmSrepNameConflictVol NsError
 var pNsErrorSmFolderUsageLimitOverPoolCapacity NsError
 var pNsErrorSmEnomem NsError
 var pNsErrorSmErrShelfNotInuse NsError
+var pNsErrorSmErrLdapAdConflict NsError
 var pNsErrorSmErrShelfPreactivationMfrErr NsError
 var pNsErrorSmUpdateBusy NsError
 var pNsErrorSmProtpolInvalidAppSync NsError
@@ -555,15 +563,16 @@ var pNsErrorSmSwupdateEinprog NsError
 var pNsErrorSmMissingCriteriaParam NsError
 var pNsErrorSmNoPathFound NsError
 var pNsErrorSmIncompatibleAppCategory NsError
-var pNsErrorSmVolmvAbortEnomove NsError
 var pNsErrorSmLimitSnapRetentionVolcoll NsError
+var pNsErrorSmVolmvAbortEnomove NsError
 var pNsErrorSmKeymgrRemove NsError
 var pNsErrorSmArrayNotReachable NsError
 var pNsErrorSmErrGroupMergeEventsPending NsError
 var pNsErrorSmSrepNameConflictVols NsError
+var pNsErrorSmErrLdapAlreadyExists NsError
 var pNsErrorSmPoolPartnerResumeUnsup NsError
-var pNsErrorSmArrayNotFound NsError
 var pNsErrorSmNoIscsiHardware NsError
+var pNsErrorSmArrayNotFound NsError
 var pNsErrorSmEnospc NsError
 var pNsErrorSmReservedPerfpolName NsError
 var pNsErrorSmInvalidRoute NsError
@@ -577,8 +586,8 @@ var pNsErrorSmNoIscsiLunAssignment NsError
 var pNsErrorSmSnapshotOffline NsError
 var pNsErrorSmDefaultGatewayNotInMgmtSubnet NsError
 var pNsErrorSmErrPassphraseAuth NsError
-var pNsErrorSmReplEexist NsError
 var pNsErrorSmDisableLastProtocol NsError
+var pNsErrorSmReplEexist NsError
 var pNsErrorSmSecondUntaggedAssignment NsError
 var pNsErrorSmPoolHasPe NsError
 var pNsErrorSmErrShelfInvalidCount NsError
@@ -594,8 +603,8 @@ var pNsErrorSmInfoConfigSyncInprogress NsError
 var pNsErrorSmErrPoolStillMerging NsError
 var pNsErrorSmFolderPerfpolAgentType NsError
 var pNsErrorSmEinval NsError
-var pNsErrorSmNoAssocVols NsError
 var pNsErrorSmShelfNotInuse NsError
+var pNsErrorSmNoAssocVols NsError
 var pNsErrorSmErrProtpolSettingsNotAllowed NsError
 var pNsErrorSmFcRegenerate NsError
 var pNsErrorSmErrMultiArrayGroup NsError
@@ -608,8 +617,8 @@ var pNsErrorSmVvolAlreadyEnabled NsError
 var pNsErrorSmUsageUnavaiable NsError
 var pNsErrorSmEconnrefused NsError
 var pNsErrorSmReplRenameNotsup NsError
-var pNsErrorSmSessionCreate NsError
 var pNsErrorSmConflictingAclVol NsError
+var pNsErrorSmSessionCreate NsError
 var pNsErrorSmNospace NsError
 var pNsErrorSmReservedVolcollName NsError
 var pNsErrorSmPoolHasFolder NsError
@@ -624,8 +633,8 @@ var pNsErrorSmInvalidArgValue NsError
 var pNsErrorSmErrShelfDedupeBelowFdr NsError
 var pNsErrorSmErrShelfInvalidAfsCount NsError
 var pNsErrorSmSerialNotAvail NsError
-var pNsErrorSmErrShelfSesMshipErr NsError
 var pNsErrorSmFolderProvisionedLimitBelowCurrentUsage NsError
+var pNsErrorSmErrShelfSesMshipErr NsError
 var pNsErrorSmPeMultiProtocolAccessNotSupported NsError
 var pNsErrorSmLimitHretSnapRetentionPool NsError
 var pNsErrorSmPeConflictingAcl NsError
@@ -633,13 +642,13 @@ var pNsErrorSmFolderOverUsageLimit NsError
 var pNsErrorSmErrEncryptionMasterKeyMissing NsError
 var pNsErrorSmProtpolInvalidDomainName NsError
 var pNsErrorSmTooMany NsError
-var pNsErrorSmErrShelfExprRevIncompatible NsError
 var pNsErrorSmSrvUnreachable NsError
 var pNsErrorSmVolumeConflict NsError
+var pNsErrorSmErrShelfExprRevIncompatible NsError
 var pNsErrorSmInvalidArrayName NsError
 var pNsErrorSmCannotReadObject NsError
-var pNsErrorSmReservedVolName NsError
 var pNsErrorSmPoolPartnerInUse NsError
+var pNsErrorSmReservedVolName NsError
 var pNsErrorSmInvalidInitiatorgrpName NsError
 var pNsErrorSmAsupValidateError NsError
 var pNsErrorSmVersionName NsError
@@ -657,13 +666,14 @@ var pNsErrorSmIscsiSvcNotAvailable NsError
 var pNsErrorSmInvalidNetconfigToDelete NsError
 var pNsErrorSmErrUnknown NsError
 var pNsErrorSmMissingCriteriaOperator NsError
-var pNsErrorSmInvalidAppUuid NsError
 var pNsErrorSmArrayMemberOrphanWithArgs NsError
-var pNsErrorSmEmptyVol NsError
+var pNsErrorSmInvalidAppUuid NsError
 var pNsErrorSmDuplicateSubnetLabel NsError
 var pNsErrorSmZeroVlanIdForTaggedAssignment NsError
+var pNsErrorSmEmptyVol NsError
 var pNsErrorSmNoActionFound NsError
 var pNsErrorSmSyncReplUnconfigureInProgress NsError
+var pNsErrorSmErrMissingArg NsError
 var pNsErrorSmVolThickProvMoveInvalid NsError
 var pNsErrorSmMissingAdvancedCriteriaConstructor NsError
 var pNsErrorSmPoolUnknown NsError
@@ -672,18 +682,18 @@ var pNsErrorSmReplThrottleOverlap NsError
 var pNsErrorSmNetconfigUpdateMismatch NsError
 var pNsErrorSmSrepDownstreamVolsAcl NsError
 var pNsErrorSmStatsFrequencyInvalid NsError
-var pNsErrorSmDdupFolderMerge NsError
 var pNsErrorSmInvalidSubnet NsError
+var pNsErrorSmDdupFolderMerge NsError
 var pNsErrorSmReplEnabled NsError
-var pNsErrorSmPoolPartnerNameConflict NsError
 var pNsErrorSmAsupPingfromMgmtipError NsError
 var pNsErrorSmEncryptionGroupScopeOverride NsError
+var pNsErrorSmPoolPartnerNameConflict NsError
 var pNsErrorSmErrMaxSessionsReached NsError
 var pNsErrorSmErrReplMultiplePartners NsError
 var pNsErrorSmStatsNoSensors NsError
 var pNsErrorSmFolderNeedsLimit NsError
-var pNsErrorSmVolmvVvol NsError
 var pNsErrorSmErrGroupMergeInprogress NsError
+var pNsErrorSmVolmvVvol NsError
 var pNsErrorSmFolderNotFound NsError
 var pNsErrorSmRouteExists NsError
 var pNsErrorSmInvalidDiscoveryIp NsError
@@ -697,28 +707,28 @@ var pNsErrorSmDuplicateIp NsError
 var pNsErrorSmNoAction NsError
 var pNsErrorSmProtpolAppSyncOracleParams NsError
 var pNsErrorSmProtpolInvalidVssSettings NsError
+var pNsErrorSmShelfRaidDegraded NsError
 var pNsErrorSmEncryptionInvalidScope NsError
 var pNsErrorSmLimitSnapcollVolcoll NsError
-var pNsErrorSmShelfRaidDegraded NsError
 var pNsErrorSmInvalidNonIscsiDataSubnetType NsError
 var pNsErrorSmVolmvIncompatibleAgentType NsError
-var pNsErrorSmReplPartnerVersionUnknown NsError
 var pNsErrorSmAsupNameresError NsError
+var pNsErrorSmReplPartnerVersionUnknown NsError
 var pNsErrorSmReplApiUnsup NsError
 var pNsErrorSmEperm NsError
 var pNsErrorSmEnoentEnoent NsError
 var pNsErrorSmArrayGroupLeader NsError
 var pNsErrorSmInvalidInitiatorIqn NsError
 var pNsErrorSmReplIntragroup NsError
-var pNsErrorSmRemoveNonemptyFolder NsError
 var pNsErrorSmAddNoniscsiToIscsiGroup NsError
-var pNsErrorSmPoolDedupeIncapable NsError
+var pNsErrorSmRemoveNonemptyFolder NsError
 var pNsErrorSmNoVvolSupport NsError
+var pNsErrorSmPoolDedupeIncapable NsError
 var pNsErrorSmNoInitiatorgrp NsError
 var pNsErrorSmInvalidNetmask NsError
 var pNsErrorSmNoDiscoveryIpInManualMode NsError
-var pNsErrorSmInvalidVolReserveValues NsError
 var pNsErrorSmSupportIpInvalid NsError
+var pNsErrorSmInvalidVolReserveValues NsError
 var pNsErrorSmErrShelfForeignDisk NsError
 var pNsErrorSmVolsnapAlreadyExported NsError
 var pNsErrorSmFcInitiatorgrpSubnetNotSupported NsError
@@ -743,17 +753,18 @@ var pNsErrorSmArrayPoolFlashMismatch NsError
 var pNsErrorSmFolderLimitInval NsError
 var pNsErrorSmShelfSsdDegraded NsError
 var pNsErrorSmFolderOverdraftLimitNeedsUsageLimit NsError
-var pNsErrorSmEncryptionMasterKeyMissing NsError
 var pNsErrorSmSrepAgentTypeMismatchDownstreamVols NsError
+var pNsErrorSmEncryptionMasterKeyMissing NsError
 var pNsErrorSmErrVolNotOfflineOnRestore NsError
 var pNsErrorSmReplHandoverBusy NsError
 var pNsErrorSmNotOwner NsError
 var pNsErrorSmSrepDownstreamAcl NsError
 var pNsErrorSmNoSubnetWithLabel NsError
 var pNsErrorSmPoolUpdateInvalArrays NsError
-var pNsErrorSmVolHasOnlineSnap NsError
 var pNsErrorSmInvalidDataIp NsError
+var pNsErrorSmVolHasOnlineSnap NsError
 var pNsErrorSmPoolVolmvEinprog NsError
+var pNsErrorSmErrLdapBindPasswordNoUser NsError
 var pNsErrorSmNoDataIpOnMgmtPlusData NsError
 var pNsErrorSmConflictingAclLun NsError
 var pNsErrorSmVpCreatedIgrp NsError
@@ -761,35 +772,35 @@ var pNsErrorSmStarterVolAclCreate NsError
 var pNsErrorSmBadPkg NsError
 var pNsErrorSmPasswdSameAsCurrent NsError
 var pNsErrorSmSnaplunsOutOfSync NsError
-var pNsErrorSmLimitSnapPool NsError
 var pNsErrorSmMultiProtocolAccessNotSupported NsError
+var pNsErrorSmLimitSnapPool NsError
 var pNsErrorSmVolHasClone NsError
 var pNsErrorSmDedupeSingleArray NsError
 var pNsErrorSmEncryptionMasterKeyInactive NsError
 var pNsErrorSmSnapHasClone NsError
 var pNsErrorSmErrEncryptionNeeded NsError
 var pNsErrorSmMismatchingDuplicateSubnet NsError
-var pNsErrorSmSrepNotGroupScopedVol NsError
 var pNsErrorSmOnlyVvolFolderFolset NsError
+var pNsErrorSmSrepNotGroupScopedVol NsError
 var pNsErrorSmReplSnapshotSync NsError
 var pNsErrorSmStatsNoSuchObject NsError
 var pNsErrorSmDefaultRouteMissing NsError
-var pNsErrorSmReplVasa3ApiUnsup NsError
 var pNsErrorSmOverlappingSubnets NsError
+var pNsErrorSmReplVasa3ApiUnsup NsError
 var pNsErrorSmMissingArg NsError
-var pNsErrorSmVolmvCachePinDedupeNotsupp NsError
 var pNsErrorSmErrMergeConflict NsError
+var pNsErrorSmVolmvCachePinDedupeNotsupp NsError
 var pNsErrorSmTooSmall NsError
 var pNsErrorSmVolWarnGreaterThanLimit NsError
 var pNsErrorSmKeymgrUnreach NsError
 var pNsErrorSmErrFcAsymmetryNotSupported NsError
 var pNsErrorSmLunMismatch NsError
-var pNsErrorSmErrShelfInvalidDiskCount NsError
 var pNsErrorSmLimitVolacl NsError
+var pNsErrorSmErrShelfInvalidDiskCount NsError
 var pNsErrorSmControllerNotActive NsError
 var pNsErrorSmReplNoPartnerAvail NsError
-var pNsErrorSmSreplMgmtOpDisallowedWhenSolo NsError
 var pNsErrorSmNoMgmtSubnetSpecified NsError
+var pNsErrorSmSreplMgmtOpDisallowedWhenSolo NsError
 var pNsErrorSmFolderConflict NsError
 var pNsErrorSmInvalidDataSubnet NsError
 var pNsErrorSmVolUsageUnavailable NsError
@@ -799,8 +810,8 @@ var pNsErrorSmDisabledProtocolArtifacts NsError
 var pNsErrorSmDuplicateSubnetVlanId NsError
 var pNsErrorSmReplOpenstackUnsup NsError
 var pNsErrorSmNoAvailableLun NsError
-var pNsErrorSmGroupPartnerNameConflict NsError
 var pNsErrorSmMgmtIpNotOnMgmt NsError
+var pNsErrorSmGroupPartnerNameConflict NsError
 var pNsErrorSmInUseLun NsError
 var pNsErrorSmNotFcInitiatorgrp NsError
 var pNsErrorSmErrShelfInvalidCsz NsError
@@ -808,15 +819,15 @@ var pNsErrorSmVolDedupeInvalidPerfPolicy NsError
 var pNsErrorSmEncryptionInvalidMode NsError
 var pNsErrorSmAsupDisabled NsError
 var pNsErrorSmErrShelfConnectedOnlyOneSide NsError
-var pNsErrorSmVolmvEnospace NsError
 var pNsErrorSmIncompatibleVolumes NsError
+var pNsErrorSmVolmvEnospace NsError
 var pNsErrorSmComplexTypeQueryParam NsError
 var pNsErrorSmAsupError NsError
 var pNsErrorSmReplUnassignedAppcat NsError
 var pNsErrorSmErrFcRegenerateInvalidOperationTdz NsError
 var pNsErrorSmInvalidPathVariable NsError
-var pNsErrorSmErrArgChangeNotAllowed NsError
 var pNsErrorSmSpecifiedSnapshotLun NsError
+var pNsErrorSmErrArgChangeNotAllowed NsError
 var pNsErrorSmSrepDownstreamAssocedVol NsError
 var pNsErrorSmLimitScopeValues NsError
 var pNsErrorSmErrPassphraseInval NsError
@@ -825,33 +836,33 @@ var pNsErrorSmCachePinnedNotsup NsError
 var pNsErrorSmNoOperationFound NsError
 var pNsErrorSmInvalidDataForPartnerType NsError
 var pNsErrorSmSrvUpdatePrecheck NsError
-var pNsErrorSmVolDedupeEncryptionInvalid NsError
-var pNsErrorSmVvolFolderNoAppsrvr NsError
 var pNsErrorSmHttpConflict NsError
+var pNsErrorSmVvolFolderNoAppsrvr NsError
+var pNsErrorSmVolDedupeEncryptionInvalid NsError
 var pNsErrorSmArrayRenameInNetconfigFailed NsError
 var pNsErrorSmInvalidInitiatorIp NsError
 var pNsErrorSmDuplicateVol NsError
 var pNsErrorSmErrShelfInvalidModel NsError
 var pNsErrorSmReplProtectLastSnap NsError
 var pNsErrorSmErrGroupMergeBusy NsError
-var pNsErrorSmErrVolmvPoolMerging NsError
 var pNsErrorSmArrayNotFoundWithArgs NsError
 var pNsErrorSmConnectionRebalancingWithoutAutomaticMethod NsError
+var pNsErrorSmErrVolmvPoolMerging NsError
 var pNsErrorSmSrepDownstreamNoCommonSnapVols NsError
-var pNsErrorSmErrShelfWrongSasPort NsError
 var pNsErrorSmFolderUsageLimitBelowCurrentUsage NsError
+var pNsErrorSmErrShelfWrongSasPort NsError
 var pNsErrorSmLimitSnapRetentionPool NsError
+var pNsErrorSmSrepNotGroupScopedVols NsError
 var pNsErrorSmErrShelfExprFwVerInval NsError
 var pNsErrorSmSrepVolcollUnsup NsError
-var pNsErrorSmSrepNotGroupScopedVols NsError
 var pNsErrorSmFcIntfNotFound NsError
 var pNsErrorSmVolUnknown NsError
 var pNsErrorSmErrShelfEbusy NsError
 var pNsErrorSmAppserverInUse NsError
-var pNsErrorSmPoolDoesNotHaveFolder NsError
 var pNsErrorSmPerfpolNotFound NsError
-var pNsErrorSmPerfpolOob NsError
 var pNsErrorSmDuplicateInitiator NsError
+var pNsErrorSmPerfpolOob NsError
+var pNsErrorSmPoolDoesNotHaveFolder NsError
 var pNsErrorSmInUseAppUuid NsError
 var pNsErrorSmPartnerCfgSync NsError
 var pNsErrorSmNotDownloadingSw NsError
@@ -859,22 +870,22 @@ var pNsErrorSmMissingMgmtIp NsError
 var pNsErrorSmSrepDownstreamNoCommonSnapVol NsError
 var pNsErrorSmEbusy NsError
 var pNsErrorSmErrReplCantConnect NsError
-var pNsErrorSmErrShelfExpanderErr NsError
 var pNsErrorSmPeFailAclRemoval NsError
+var pNsErrorSmErrShelfExpanderErr NsError
 var pNsErrorSmSupportIpNotOnMgmt NsError
 var pNsErrorSmAtLeastOneGroupSubnet NsError
 var pNsErrorSmUnsupportedAccessProtocol NsError
 var pNsErrorSmSpaceInfoUnavail NsError
 var pNsErrorSmLimitVolmvHretSnapPool NsError
+var pNsErrorSmDataIpNotOnSubnet NsError
 var pNsErrorSmStartTimeBeyondEndTime NsError
 var pNsErrorSmReplRemotePaused NsError
-var pNsErrorSmDataIpNotOnSubnet NsError
 var pNsErrorSmConflictingInitiatorAlias NsError
 var pNsErrorSmReplEditPartnerNameNotPaused NsError
 var pNsErrorSmShelfForeignDisk NsError
 var pNsErrorSmQosLimitNotInRange NsError
-var pNsErrorSmErrShelfNoRserial NsError
 var pNsErrorSmUntaggedMtuNotLargest NsError
+var pNsErrorSmErrShelfNoRserial NsError
 var pNsErrorSmErrShelfDisconnected NsError
 var pNsErrorSmSubnetAlreadyAssignedOnNic NsError
 var pNsErrorSmFcSessionExist NsError
@@ -888,14 +899,14 @@ var pNsErrorSmInvalidQueryParam NsError
 var pNsErrorSmErrGroupMergeDbLoad NsError
 var pNsErrorSmEio NsError
 var pNsErrorSmSrepDownstreamOnlineVol NsError
-var pNsErrorSmPoolNoSrcArray NsError
 var pNsErrorSmInvalidKeyvalue NsError
+var pNsErrorSmPoolNoSrcArray NsError
 var pNsErrorSmProtpolMaxLength NsError
 var pNsErrorSmVolAssocVolcoll NsError
 var pNsErrorSmMissingDiscoveryIp NsError
 var pNsErrorSmReplDeleteReplicaUnsup NsError
-var pNsErrorSmVolSizeDecreased NsError
 var pNsErrorSmSrepDownstreamAssocedVols NsError
+var pNsErrorSmVolSizeDecreased NsError
 var pNsErrorSmAddNonfcToFcGroup NsError
 var pNsErrorSmNetconfigDoesNotExist NsError
 var pNsErrorSmFolderVolmvEnospace NsError
@@ -916,8 +927,8 @@ var pNsErrorSmArrayNotGroupLeader NsError
 var pNsErrorSmInvalidVlanId NsError
 var pNsErrorSmLimitSnaplun NsError
 var pNsErrorSmIncompatibleCachePolicy NsError
-var pNsErrorSmVolmvAbortEnospace NsError
 var pNsErrorSmLimitHretSnapGroup NsError
+var pNsErrorSmVolmvAbortEnospace NsError
 var pNsErrorSmVolmvEalready NsError
 var pNsErrorSmAsupPingfromCtrlrbError NsError
 var pNsErrorSmVolDedupeUnassignedAppCategory NsError
@@ -926,8 +937,8 @@ var pNsErrorSmPerfpolDedupeUnassignedAppCategory NsError
 var pNsErrorSmInvalidInitiatorLabel NsError
 var pNsErrorSmDuplicateInitiatorWithArgs NsError
 var pNsErrorSmErrShelfForeign NsError
-var pNsErrorSmInvalidAgentType NsError
 var pNsErrorSmEinprogress NsError
+var pNsErrorSmInvalidAgentType NsError
 var pNsErrorSmNotEnoughCache NsError
 var pNsErrorSmEexist NsError
 var pNsErrorSmMissingArrayNetconfig NsError
@@ -943,9 +954,9 @@ var pNsErrorSmUsageUnavailable NsError
 var pNsErrorSmReplAgentTypeUnsup NsError
 var pNsErrorSmReplFanoutMaximumPartnersExceeded NsError
 var pNsErrorSmAsupPingfromCtrlraError NsError
+var pNsErrorSmSyncReplConfigure NsError
 var pNsErrorSmErrShelfInvalidLoc NsError
 var pNsErrorSmErrShelfSsdDegraded NsError
-var pNsErrorSmSyncReplConfigure NsError
 var pNsErrorSmAsupHeartbeatError NsError
 var pNsErrorSmLimitHretSnapRetentionPoolWarn NsError
 var pNsErrorSmErrAuth NsError
@@ -955,10 +966,10 @@ var pNsErrorSmFolderEnospace NsError
 var pNsErrorSmErrPoolHasGroupPartners NsError
 var pNsErrorSmProtpolNotSpecified NsError
 var pNsErrorSmUnexpectedQueryParam NsError
-var pNsErrorSmVolmvAbortEalready NsError
 var pNsErrorSmFcIntfAlreadyInState NsError
-var pNsErrorSmLimitHretSnapPool NsError
 var pNsErrorSmIpUpdateNoForce NsError
+var pNsErrorSmLimitHretSnapPool NsError
+var pNsErrorSmVolmvAbortEalready NsError
 var pNsErrorSmSrepAgentTypeMismatchDownstreamVol NsError
 var pNsErrorSmVssValidationTimedout NsError
 var pNsErrorSmConfigSyncInprogress NsError
@@ -975,8 +986,8 @@ var pNsErrorSmNoDataIpSpecified NsError
 var pNsErrorSmInvalidVolAssoc NsError
 var pNsErrorSmReplObjectBusy NsError
 var pNsErrorSmVolcollOwner NsError
-var pNsErrorSmReservedUsername NsError
 var pNsErrorSmVvolsnapOnline NsError
+var pNsErrorSmReservedUsername NsError
 var pNsErrorSmFolderVolmvEinprog NsError
 var pNsErrorSmUnexpectedObjectSetQuery NsError
 var pNsErrorSmProtpolInvalidValue NsError
@@ -987,6 +998,7 @@ var pNsErrorSmReplPartnerNameMismatch NsError
 var pNsErrorSmInvalidFolder NsError
 var pNsErrorSmSrvUpdatePrecheckArray NsError
 var pNsErrorSmGatewayNotInSubnets NsError
+var pNsErrorSmErrLdapBindUserNoPassword NsError
 var pNsErrorSmDeprecatedPerfpol NsError
 var pNsErrorSmTakeoverSplitBrain NsError
 var pNsErrorSmPeIgroupProtocolMismatched NsError
@@ -1000,8 +1012,8 @@ var pNsErrorSmDedupeVolfamAppcat NsError
 var pNsErrorSmSrvUnreach NsError
 var pNsErrorSmPoolPartnerPauseUnsup NsError
 var pNsErrorSmNetconfigCreateDraftOnly NsError
-var pNsErrorSmErrArrayNotFound NsError
 var pNsErrorSmFolsetInUse NsError
+var pNsErrorSmErrArrayNotFound NsError
 var pNsErrorSmErrShelfSesDeviceNotReady NsError
 var pNsErrorSmInvalidIp NsError
 var pNsErrorSmEalready NsError
@@ -1013,18 +1025,18 @@ var pNsErrorSmErrProtpolMissingName NsError
 var pNsErrorSmVfVolCachePinned NsError
 var pNsErrorSmAtLeastOneIscsiCluster NsError
 var pNsErrorSmErrTooMany NsError
-var pNsErrorSmErrShelfExprMfgVerInval NsError
 var pNsErrorSmMgmtIpInvalid NsError
+var pNsErrorSmErrShelfExprMfgVerInval NsError
 var pNsErrorSmErrShelfWrongCtrlrSide NsError
 
 // NsErrorSmReplVolcollDeletion enum exports
 var NsErrorSmReplVolcollDeletion *NsError
 
-// NsErrorSmEncryptionGroupCipherOverride enum exports
-var NsErrorSmEncryptionGroupCipherOverride *NsError
-
 // NsErrorSmEncryptionMustBeEnabled enum exports
 var NsErrorSmEncryptionMustBeEnabled *NsError
+
+// NsErrorSmEncryptionGroupCipherOverride enum exports
+var NsErrorSmEncryptionGroupCipherOverride *NsError
 
 // NsErrorSmExtTrigSchedNotPresent enum exports
 var NsErrorSmExtTrigSchedNotPresent *NsError
@@ -1037,6 +1049,9 @@ var NsErrorSmFolderReplPartner *NsError
 
 // NsErrorSmArrayPoolMember enum exports
 var NsErrorSmArrayPoolMember *NsError
+
+// NsErrorSmErrInvalidArg enum exports
+var NsErrorSmErrInvalidArg *NsError
 
 // NsErrorSmErrShelfCreateRfail enum exports
 var NsErrorSmErrShelfCreateRfail *NsError
@@ -1104,11 +1119,11 @@ var NsErrorSmKeymgrLeave *NsError
 // NsErrorSmVolmvVolEinprog enum exports
 var NsErrorSmVolmvVolEinprog *NsError
 
-// NsErrorSmSrepNameConflictVol enum exports
-var NsErrorSmSrepNameConflictVol *NsError
-
 // NsErrorSmMultiArrayWithoutAutomaticConnectionMethod enum exports
 var NsErrorSmMultiArrayWithoutAutomaticConnectionMethod *NsError
+
+// NsErrorSmSrepNameConflictVol enum exports
+var NsErrorSmSrepNameConflictVol *NsError
 
 // NsErrorSmFolderUsageLimitOverPoolCapacity enum exports
 var NsErrorSmFolderUsageLimitOverPoolCapacity *NsError
@@ -1118,6 +1133,9 @@ var NsErrorSmEnomem *NsError
 
 // NsErrorSmErrShelfNotInuse enum exports
 var NsErrorSmErrShelfNotInuse *NsError
+
+// NsErrorSmErrLdapAdConflict enum exports
+var NsErrorSmErrLdapAdConflict *NsError
 
 // NsErrorSmErrShelfPreactivationMfrErr enum exports
 var NsErrorSmErrShelfPreactivationMfrErr *NsError
@@ -1146,11 +1164,11 @@ var NsErrorSmNoPathFound *NsError
 // NsErrorSmIncompatibleAppCategory enum exports
 var NsErrorSmIncompatibleAppCategory *NsError
 
-// NsErrorSmVolmvAbortEnomove enum exports
-var NsErrorSmVolmvAbortEnomove *NsError
-
 // NsErrorSmLimitSnapRetentionVolcoll enum exports
 var NsErrorSmLimitSnapRetentionVolcoll *NsError
+
+// NsErrorSmVolmvAbortEnomove enum exports
+var NsErrorSmVolmvAbortEnomove *NsError
 
 // NsErrorSmKeymgrRemove enum exports
 var NsErrorSmKeymgrRemove *NsError
@@ -1164,14 +1182,17 @@ var NsErrorSmErrGroupMergeEventsPending *NsError
 // NsErrorSmSrepNameConflictVols enum exports
 var NsErrorSmSrepNameConflictVols *NsError
 
+// NsErrorSmErrLdapAlreadyExists enum exports
+var NsErrorSmErrLdapAlreadyExists *NsError
+
 // NsErrorSmPoolPartnerResumeUnsup enum exports
 var NsErrorSmPoolPartnerResumeUnsup *NsError
 
-// NsErrorSmArrayNotFound enum exports
-var NsErrorSmArrayNotFound *NsError
-
 // NsErrorSmNoIscsiHardware enum exports
 var NsErrorSmNoIscsiHardware *NsError
+
+// NsErrorSmArrayNotFound enum exports
+var NsErrorSmArrayNotFound *NsError
 
 // NsErrorSmEnospc enum exports
 var NsErrorSmEnospc *NsError
@@ -1212,11 +1233,11 @@ var NsErrorSmDefaultGatewayNotInMgmtSubnet *NsError
 // NsErrorSmErrPassphraseAuth enum exports
 var NsErrorSmErrPassphraseAuth *NsError
 
-// NsErrorSmReplEexist enum exports
-var NsErrorSmReplEexist *NsError
-
 // NsErrorSmDisableLastProtocol enum exports
 var NsErrorSmDisableLastProtocol *NsError
+
+// NsErrorSmReplEexist enum exports
+var NsErrorSmReplEexist *NsError
 
 // NsErrorSmSecondUntaggedAssignment enum exports
 var NsErrorSmSecondUntaggedAssignment *NsError
@@ -1263,11 +1284,11 @@ var NsErrorSmFolderPerfpolAgentType *NsError
 // NsErrorSmEinval enum exports
 var NsErrorSmEinval *NsError
 
-// NsErrorSmNoAssocVols enum exports
-var NsErrorSmNoAssocVols *NsError
-
 // NsErrorSmShelfNotInuse enum exports
 var NsErrorSmShelfNotInuse *NsError
+
+// NsErrorSmNoAssocVols enum exports
+var NsErrorSmNoAssocVols *NsError
 
 // NsErrorSmErrProtpolSettingsNotAllowed enum exports
 var NsErrorSmErrProtpolSettingsNotAllowed *NsError
@@ -1305,11 +1326,11 @@ var NsErrorSmEconnrefused *NsError
 // NsErrorSmReplRenameNotsup enum exports
 var NsErrorSmReplRenameNotsup *NsError
 
-// NsErrorSmSessionCreate enum exports
-var NsErrorSmSessionCreate *NsError
-
 // NsErrorSmConflictingAclVol enum exports
 var NsErrorSmConflictingAclVol *NsError
+
+// NsErrorSmSessionCreate enum exports
+var NsErrorSmSessionCreate *NsError
 
 // NsErrorSmNospace enum exports
 var NsErrorSmNospace *NsError
@@ -1353,11 +1374,11 @@ var NsErrorSmErrShelfInvalidAfsCount *NsError
 // NsErrorSmSerialNotAvail enum exports
 var NsErrorSmSerialNotAvail *NsError
 
-// NsErrorSmErrShelfSesMshipErr enum exports
-var NsErrorSmErrShelfSesMshipErr *NsError
-
 // NsErrorSmFolderProvisionedLimitBelowCurrentUsage enum exports
 var NsErrorSmFolderProvisionedLimitBelowCurrentUsage *NsError
+
+// NsErrorSmErrShelfSesMshipErr enum exports
+var NsErrorSmErrShelfSesMshipErr *NsError
 
 // NsErrorSmPeMultiProtocolAccessNotSupported enum exports
 var NsErrorSmPeMultiProtocolAccessNotSupported *NsError
@@ -1380,14 +1401,14 @@ var NsErrorSmProtpolInvalidDomainName *NsError
 // NsErrorSmTooMany enum exports
 var NsErrorSmTooMany *NsError
 
-// NsErrorSmErrShelfExprRevIncompatible enum exports
-var NsErrorSmErrShelfExprRevIncompatible *NsError
-
 // NsErrorSmSrvUnreachable enum exports
 var NsErrorSmSrvUnreachable *NsError
 
 // NsErrorSmVolumeConflict enum exports
 var NsErrorSmVolumeConflict *NsError
+
+// NsErrorSmErrShelfExprRevIncompatible enum exports
+var NsErrorSmErrShelfExprRevIncompatible *NsError
 
 // NsErrorSmInvalidArrayName enum exports
 var NsErrorSmInvalidArrayName *NsError
@@ -1395,11 +1416,11 @@ var NsErrorSmInvalidArrayName *NsError
 // NsErrorSmCannotReadObject enum exports
 var NsErrorSmCannotReadObject *NsError
 
-// NsErrorSmReservedVolName enum exports
-var NsErrorSmReservedVolName *NsError
-
 // NsErrorSmPoolPartnerInUse enum exports
 var NsErrorSmPoolPartnerInUse *NsError
+
+// NsErrorSmReservedVolName enum exports
+var NsErrorSmReservedVolName *NsError
 
 // NsErrorSmInvalidInitiatorgrpName enum exports
 var NsErrorSmInvalidInitiatorgrpName *NsError
@@ -1452,14 +1473,11 @@ var NsErrorSmErrUnknown *NsError
 // NsErrorSmMissingCriteriaOperator enum exports
 var NsErrorSmMissingCriteriaOperator *NsError
 
-// NsErrorSmInvalidAppUuid enum exports
-var NsErrorSmInvalidAppUuid *NsError
-
 // NsErrorSmArrayMemberOrphanWithArgs enum exports
 var NsErrorSmArrayMemberOrphanWithArgs *NsError
 
-// NsErrorSmEmptyVol enum exports
-var NsErrorSmEmptyVol *NsError
+// NsErrorSmInvalidAppUuid enum exports
+var NsErrorSmInvalidAppUuid *NsError
 
 // NsErrorSmDuplicateSubnetLabel enum exports
 var NsErrorSmDuplicateSubnetLabel *NsError
@@ -1467,11 +1485,17 @@ var NsErrorSmDuplicateSubnetLabel *NsError
 // NsErrorSmZeroVlanIdForTaggedAssignment enum exports
 var NsErrorSmZeroVlanIdForTaggedAssignment *NsError
 
+// NsErrorSmEmptyVol enum exports
+var NsErrorSmEmptyVol *NsError
+
 // NsErrorSmNoActionFound enum exports
 var NsErrorSmNoActionFound *NsError
 
 // NsErrorSmSyncReplUnconfigureInProgress enum exports
 var NsErrorSmSyncReplUnconfigureInProgress *NsError
+
+// NsErrorSmErrMissingArg enum exports
+var NsErrorSmErrMissingArg *NsError
 
 // NsErrorSmVolThickProvMoveInvalid enum exports
 var NsErrorSmVolThickProvMoveInvalid *NsError
@@ -1497,23 +1521,23 @@ var NsErrorSmSrepDownstreamVolsAcl *NsError
 // NsErrorSmStatsFrequencyInvalid enum exports
 var NsErrorSmStatsFrequencyInvalid *NsError
 
-// NsErrorSmDdupFolderMerge enum exports
-var NsErrorSmDdupFolderMerge *NsError
-
 // NsErrorSmInvalidSubnet enum exports
 var NsErrorSmInvalidSubnet *NsError
 
+// NsErrorSmDdupFolderMerge enum exports
+var NsErrorSmDdupFolderMerge *NsError
+
 // NsErrorSmReplEnabled enum exports
 var NsErrorSmReplEnabled *NsError
-
-// NsErrorSmPoolPartnerNameConflict enum exports
-var NsErrorSmPoolPartnerNameConflict *NsError
 
 // NsErrorSmAsupPingfromMgmtipError enum exports
 var NsErrorSmAsupPingfromMgmtipError *NsError
 
 // NsErrorSmEncryptionGroupScopeOverride enum exports
 var NsErrorSmEncryptionGroupScopeOverride *NsError
+
+// NsErrorSmPoolPartnerNameConflict enum exports
+var NsErrorSmPoolPartnerNameConflict *NsError
 
 // NsErrorSmErrMaxSessionsReached enum exports
 var NsErrorSmErrMaxSessionsReached *NsError
@@ -1527,11 +1551,11 @@ var NsErrorSmStatsNoSensors *NsError
 // NsErrorSmFolderNeedsLimit enum exports
 var NsErrorSmFolderNeedsLimit *NsError
 
-// NsErrorSmVolmvVvol enum exports
-var NsErrorSmVolmvVvol *NsError
-
 // NsErrorSmErrGroupMergeInprogress enum exports
 var NsErrorSmErrGroupMergeInprogress *NsError
+
+// NsErrorSmVolmvVvol enum exports
+var NsErrorSmVolmvVvol *NsError
 
 // NsErrorSmFolderNotFound enum exports
 var NsErrorSmFolderNotFound *NsError
@@ -1572,14 +1596,14 @@ var NsErrorSmProtpolAppSyncOracleParams *NsError
 // NsErrorSmProtpolInvalidVssSettings enum exports
 var NsErrorSmProtpolInvalidVssSettings *NsError
 
+// NsErrorSmShelfRaidDegraded enum exports
+var NsErrorSmShelfRaidDegraded *NsError
+
 // NsErrorSmEncryptionInvalidScope enum exports
 var NsErrorSmEncryptionInvalidScope *NsError
 
 // NsErrorSmLimitSnapcollVolcoll enum exports
 var NsErrorSmLimitSnapcollVolcoll *NsError
-
-// NsErrorSmShelfRaidDegraded enum exports
-var NsErrorSmShelfRaidDegraded *NsError
 
 // NsErrorSmInvalidNonIscsiDataSubnetType enum exports
 var NsErrorSmInvalidNonIscsiDataSubnetType *NsError
@@ -1587,11 +1611,11 @@ var NsErrorSmInvalidNonIscsiDataSubnetType *NsError
 // NsErrorSmVolmvIncompatibleAgentType enum exports
 var NsErrorSmVolmvIncompatibleAgentType *NsError
 
-// NsErrorSmReplPartnerVersionUnknown enum exports
-var NsErrorSmReplPartnerVersionUnknown *NsError
-
 // NsErrorSmAsupNameresError enum exports
 var NsErrorSmAsupNameresError *NsError
+
+// NsErrorSmReplPartnerVersionUnknown enum exports
+var NsErrorSmReplPartnerVersionUnknown *NsError
 
 // NsErrorSmReplApiUnsup enum exports
 var NsErrorSmReplApiUnsup *NsError
@@ -1611,17 +1635,17 @@ var NsErrorSmInvalidInitiatorIqn *NsError
 // NsErrorSmReplIntragroup enum exports
 var NsErrorSmReplIntragroup *NsError
 
-// NsErrorSmRemoveNonemptyFolder enum exports
-var NsErrorSmRemoveNonemptyFolder *NsError
-
 // NsErrorSmAddNoniscsiToIscsiGroup enum exports
 var NsErrorSmAddNoniscsiToIscsiGroup *NsError
 
-// NsErrorSmPoolDedupeIncapable enum exports
-var NsErrorSmPoolDedupeIncapable *NsError
+// NsErrorSmRemoveNonemptyFolder enum exports
+var NsErrorSmRemoveNonemptyFolder *NsError
 
 // NsErrorSmNoVvolSupport enum exports
 var NsErrorSmNoVvolSupport *NsError
+
+// NsErrorSmPoolDedupeIncapable enum exports
+var NsErrorSmPoolDedupeIncapable *NsError
 
 // NsErrorSmNoInitiatorgrp enum exports
 var NsErrorSmNoInitiatorgrp *NsError
@@ -1632,11 +1656,11 @@ var NsErrorSmInvalidNetmask *NsError
 // NsErrorSmNoDiscoveryIpInManualMode enum exports
 var NsErrorSmNoDiscoveryIpInManualMode *NsError
 
-// NsErrorSmInvalidVolReserveValues enum exports
-var NsErrorSmInvalidVolReserveValues *NsError
-
 // NsErrorSmSupportIpInvalid enum exports
 var NsErrorSmSupportIpInvalid *NsError
+
+// NsErrorSmInvalidVolReserveValues enum exports
+var NsErrorSmInvalidVolReserveValues *NsError
 
 // NsErrorSmErrShelfForeignDisk enum exports
 var NsErrorSmErrShelfForeignDisk *NsError
@@ -1710,11 +1734,11 @@ var NsErrorSmShelfSsdDegraded *NsError
 // NsErrorSmFolderOverdraftLimitNeedsUsageLimit enum exports
 var NsErrorSmFolderOverdraftLimitNeedsUsageLimit *NsError
 
-// NsErrorSmEncryptionMasterKeyMissing enum exports
-var NsErrorSmEncryptionMasterKeyMissing *NsError
-
 // NsErrorSmSrepAgentTypeMismatchDownstreamVols enum exports
 var NsErrorSmSrepAgentTypeMismatchDownstreamVols *NsError
+
+// NsErrorSmEncryptionMasterKeyMissing enum exports
+var NsErrorSmEncryptionMasterKeyMissing *NsError
 
 // NsErrorSmErrVolNotOfflineOnRestore enum exports
 var NsErrorSmErrVolNotOfflineOnRestore *NsError
@@ -1734,14 +1758,17 @@ var NsErrorSmNoSubnetWithLabel *NsError
 // NsErrorSmPoolUpdateInvalArrays enum exports
 var NsErrorSmPoolUpdateInvalArrays *NsError
 
-// NsErrorSmVolHasOnlineSnap enum exports
-var NsErrorSmVolHasOnlineSnap *NsError
-
 // NsErrorSmInvalidDataIp enum exports
 var NsErrorSmInvalidDataIp *NsError
 
+// NsErrorSmVolHasOnlineSnap enum exports
+var NsErrorSmVolHasOnlineSnap *NsError
+
 // NsErrorSmPoolVolmvEinprog enum exports
 var NsErrorSmPoolVolmvEinprog *NsError
+
+// NsErrorSmErrLdapBindPasswordNoUser enum exports
+var NsErrorSmErrLdapBindPasswordNoUser *NsError
 
 // NsErrorSmNoDataIpOnMgmtPlusData enum exports
 var NsErrorSmNoDataIpOnMgmtPlusData *NsError
@@ -1764,11 +1791,11 @@ var NsErrorSmPasswdSameAsCurrent *NsError
 // NsErrorSmSnaplunsOutOfSync enum exports
 var NsErrorSmSnaplunsOutOfSync *NsError
 
-// NsErrorSmLimitSnapPool enum exports
-var NsErrorSmLimitSnapPool *NsError
-
 // NsErrorSmMultiProtocolAccessNotSupported enum exports
 var NsErrorSmMultiProtocolAccessNotSupported *NsError
+
+// NsErrorSmLimitSnapPool enum exports
+var NsErrorSmLimitSnapPool *NsError
 
 // NsErrorSmVolHasClone enum exports
 var NsErrorSmVolHasClone *NsError
@@ -1788,11 +1815,11 @@ var NsErrorSmErrEncryptionNeeded *NsError
 // NsErrorSmMismatchingDuplicateSubnet enum exports
 var NsErrorSmMismatchingDuplicateSubnet *NsError
 
-// NsErrorSmSrepNotGroupScopedVol enum exports
-var NsErrorSmSrepNotGroupScopedVol *NsError
-
 // NsErrorSmOnlyVvolFolderFolset enum exports
 var NsErrorSmOnlyVvolFolderFolset *NsError
+
+// NsErrorSmSrepNotGroupScopedVol enum exports
+var NsErrorSmSrepNotGroupScopedVol *NsError
 
 // NsErrorSmReplSnapshotSync enum exports
 var NsErrorSmReplSnapshotSync *NsError
@@ -1803,20 +1830,20 @@ var NsErrorSmStatsNoSuchObject *NsError
 // NsErrorSmDefaultRouteMissing enum exports
 var NsErrorSmDefaultRouteMissing *NsError
 
-// NsErrorSmReplVasa3ApiUnsup enum exports
-var NsErrorSmReplVasa3ApiUnsup *NsError
-
 // NsErrorSmOverlappingSubnets enum exports
 var NsErrorSmOverlappingSubnets *NsError
+
+// NsErrorSmReplVasa3ApiUnsup enum exports
+var NsErrorSmReplVasa3ApiUnsup *NsError
 
 // NsErrorSmMissingArg enum exports
 var NsErrorSmMissingArg *NsError
 
-// NsErrorSmVolmvCachePinDedupeNotsupp enum exports
-var NsErrorSmVolmvCachePinDedupeNotsupp *NsError
-
 // NsErrorSmErrMergeConflict enum exports
 var NsErrorSmErrMergeConflict *NsError
+
+// NsErrorSmVolmvCachePinDedupeNotsupp enum exports
+var NsErrorSmVolmvCachePinDedupeNotsupp *NsError
 
 // NsErrorSmTooSmall enum exports
 var NsErrorSmTooSmall *NsError
@@ -1833,11 +1860,11 @@ var NsErrorSmErrFcAsymmetryNotSupported *NsError
 // NsErrorSmLunMismatch enum exports
 var NsErrorSmLunMismatch *NsError
 
-// NsErrorSmErrShelfInvalidDiskCount enum exports
-var NsErrorSmErrShelfInvalidDiskCount *NsError
-
 // NsErrorSmLimitVolacl enum exports
 var NsErrorSmLimitVolacl *NsError
+
+// NsErrorSmErrShelfInvalidDiskCount enum exports
+var NsErrorSmErrShelfInvalidDiskCount *NsError
 
 // NsErrorSmControllerNotActive enum exports
 var NsErrorSmControllerNotActive *NsError
@@ -1845,11 +1872,11 @@ var NsErrorSmControllerNotActive *NsError
 // NsErrorSmReplNoPartnerAvail enum exports
 var NsErrorSmReplNoPartnerAvail *NsError
 
-// NsErrorSmSreplMgmtOpDisallowedWhenSolo enum exports
-var NsErrorSmSreplMgmtOpDisallowedWhenSolo *NsError
-
 // NsErrorSmNoMgmtSubnetSpecified enum exports
 var NsErrorSmNoMgmtSubnetSpecified *NsError
+
+// NsErrorSmSreplMgmtOpDisallowedWhenSolo enum exports
+var NsErrorSmSreplMgmtOpDisallowedWhenSolo *NsError
 
 // NsErrorSmFolderConflict enum exports
 var NsErrorSmFolderConflict *NsError
@@ -1878,11 +1905,11 @@ var NsErrorSmReplOpenstackUnsup *NsError
 // NsErrorSmNoAvailableLun enum exports
 var NsErrorSmNoAvailableLun *NsError
 
-// NsErrorSmGroupPartnerNameConflict enum exports
-var NsErrorSmGroupPartnerNameConflict *NsError
-
 // NsErrorSmMgmtIpNotOnMgmt enum exports
 var NsErrorSmMgmtIpNotOnMgmt *NsError
+
+// NsErrorSmGroupPartnerNameConflict enum exports
+var NsErrorSmGroupPartnerNameConflict *NsError
 
 // NsErrorSmInUseLun enum exports
 var NsErrorSmInUseLun *NsError
@@ -1905,11 +1932,11 @@ var NsErrorSmAsupDisabled *NsError
 // NsErrorSmErrShelfConnectedOnlyOneSide enum exports
 var NsErrorSmErrShelfConnectedOnlyOneSide *NsError
 
-// NsErrorSmVolmvEnospace enum exports
-var NsErrorSmVolmvEnospace *NsError
-
 // NsErrorSmIncompatibleVolumes enum exports
 var NsErrorSmIncompatibleVolumes *NsError
+
+// NsErrorSmVolmvEnospace enum exports
+var NsErrorSmVolmvEnospace *NsError
 
 // NsErrorSmComplexTypeQueryParam enum exports
 var NsErrorSmComplexTypeQueryParam *NsError
@@ -1926,11 +1953,11 @@ var NsErrorSmErrFcRegenerateInvalidOperationTdz *NsError
 // NsErrorSmInvalidPathVariable enum exports
 var NsErrorSmInvalidPathVariable *NsError
 
-// NsErrorSmErrArgChangeNotAllowed enum exports
-var NsErrorSmErrArgChangeNotAllowed *NsError
-
 // NsErrorSmSpecifiedSnapshotLun enum exports
 var NsErrorSmSpecifiedSnapshotLun *NsError
+
+// NsErrorSmErrArgChangeNotAllowed enum exports
+var NsErrorSmErrArgChangeNotAllowed *NsError
 
 // NsErrorSmSrepDownstreamAssocedVol enum exports
 var NsErrorSmSrepDownstreamAssocedVol *NsError
@@ -1956,14 +1983,14 @@ var NsErrorSmInvalidDataForPartnerType *NsError
 // NsErrorSmSrvUpdatePrecheck enum exports
 var NsErrorSmSrvUpdatePrecheck *NsError
 
-// NsErrorSmVolDedupeEncryptionInvalid enum exports
-var NsErrorSmVolDedupeEncryptionInvalid *NsError
+// NsErrorSmHttpConflict enum exports
+var NsErrorSmHttpConflict *NsError
 
 // NsErrorSmVvolFolderNoAppsrvr enum exports
 var NsErrorSmVvolFolderNoAppsrvr *NsError
 
-// NsErrorSmHttpConflict enum exports
-var NsErrorSmHttpConflict *NsError
+// NsErrorSmVolDedupeEncryptionInvalid enum exports
+var NsErrorSmVolDedupeEncryptionInvalid *NsError
 
 // NsErrorSmArrayRenameInNetconfigFailed enum exports
 var NsErrorSmArrayRenameInNetconfigFailed *NsError
@@ -1983,35 +2010,35 @@ var NsErrorSmReplProtectLastSnap *NsError
 // NsErrorSmErrGroupMergeBusy enum exports
 var NsErrorSmErrGroupMergeBusy *NsError
 
-// NsErrorSmErrVolmvPoolMerging enum exports
-var NsErrorSmErrVolmvPoolMerging *NsError
-
 // NsErrorSmArrayNotFoundWithArgs enum exports
 var NsErrorSmArrayNotFoundWithArgs *NsError
 
 // NsErrorSmConnectionRebalancingWithoutAutomaticMethod enum exports
 var NsErrorSmConnectionRebalancingWithoutAutomaticMethod *NsError
 
+// NsErrorSmErrVolmvPoolMerging enum exports
+var NsErrorSmErrVolmvPoolMerging *NsError
+
 // NsErrorSmSrepDownstreamNoCommonSnapVols enum exports
 var NsErrorSmSrepDownstreamNoCommonSnapVols *NsError
-
-// NsErrorSmErrShelfWrongSasPort enum exports
-var NsErrorSmErrShelfWrongSasPort *NsError
 
 // NsErrorSmFolderUsageLimitBelowCurrentUsage enum exports
 var NsErrorSmFolderUsageLimitBelowCurrentUsage *NsError
 
+// NsErrorSmErrShelfWrongSasPort enum exports
+var NsErrorSmErrShelfWrongSasPort *NsError
+
 // NsErrorSmLimitSnapRetentionPool enum exports
 var NsErrorSmLimitSnapRetentionPool *NsError
+
+// NsErrorSmSrepNotGroupScopedVols enum exports
+var NsErrorSmSrepNotGroupScopedVols *NsError
 
 // NsErrorSmErrShelfExprFwVerInval enum exports
 var NsErrorSmErrShelfExprFwVerInval *NsError
 
 // NsErrorSmSrepVolcollUnsup enum exports
 var NsErrorSmSrepVolcollUnsup *NsError
-
-// NsErrorSmSrepNotGroupScopedVols enum exports
-var NsErrorSmSrepNotGroupScopedVols *NsError
 
 // NsErrorSmFcIntfNotFound enum exports
 var NsErrorSmFcIntfNotFound *NsError
@@ -2025,17 +2052,17 @@ var NsErrorSmErrShelfEbusy *NsError
 // NsErrorSmAppserverInUse enum exports
 var NsErrorSmAppserverInUse *NsError
 
-// NsErrorSmPoolDoesNotHaveFolder enum exports
-var NsErrorSmPoolDoesNotHaveFolder *NsError
-
 // NsErrorSmPerfpolNotFound enum exports
 var NsErrorSmPerfpolNotFound *NsError
+
+// NsErrorSmDuplicateInitiator enum exports
+var NsErrorSmDuplicateInitiator *NsError
 
 // NsErrorSmPerfpolOob enum exports
 var NsErrorSmPerfpolOob *NsError
 
-// NsErrorSmDuplicateInitiator enum exports
-var NsErrorSmDuplicateInitiator *NsError
+// NsErrorSmPoolDoesNotHaveFolder enum exports
+var NsErrorSmPoolDoesNotHaveFolder *NsError
 
 // NsErrorSmInUseAppUuid enum exports
 var NsErrorSmInUseAppUuid *NsError
@@ -2058,11 +2085,11 @@ var NsErrorSmEbusy *NsError
 // NsErrorSmErrReplCantConnect enum exports
 var NsErrorSmErrReplCantConnect *NsError
 
-// NsErrorSmErrShelfExpanderErr enum exports
-var NsErrorSmErrShelfExpanderErr *NsError
-
 // NsErrorSmPeFailAclRemoval enum exports
 var NsErrorSmPeFailAclRemoval *NsError
+
+// NsErrorSmErrShelfExpanderErr enum exports
+var NsErrorSmErrShelfExpanderErr *NsError
 
 // NsErrorSmSupportIpNotOnMgmt enum exports
 var NsErrorSmSupportIpNotOnMgmt *NsError
@@ -2079,14 +2106,14 @@ var NsErrorSmSpaceInfoUnavail *NsError
 // NsErrorSmLimitVolmvHretSnapPool enum exports
 var NsErrorSmLimitVolmvHretSnapPool *NsError
 
+// NsErrorSmDataIpNotOnSubnet enum exports
+var NsErrorSmDataIpNotOnSubnet *NsError
+
 // NsErrorSmStartTimeBeyondEndTime enum exports
 var NsErrorSmStartTimeBeyondEndTime *NsError
 
 // NsErrorSmReplRemotePaused enum exports
 var NsErrorSmReplRemotePaused *NsError
-
-// NsErrorSmDataIpNotOnSubnet enum exports
-var NsErrorSmDataIpNotOnSubnet *NsError
 
 // NsErrorSmConflictingInitiatorAlias enum exports
 var NsErrorSmConflictingInitiatorAlias *NsError
@@ -2100,11 +2127,11 @@ var NsErrorSmShelfForeignDisk *NsError
 // NsErrorSmQosLimitNotInRange enum exports
 var NsErrorSmQosLimitNotInRange *NsError
 
-// NsErrorSmErrShelfNoRserial enum exports
-var NsErrorSmErrShelfNoRserial *NsError
-
 // NsErrorSmUntaggedMtuNotLargest enum exports
 var NsErrorSmUntaggedMtuNotLargest *NsError
+
+// NsErrorSmErrShelfNoRserial enum exports
+var NsErrorSmErrShelfNoRserial *NsError
 
 // NsErrorSmErrShelfDisconnected enum exports
 var NsErrorSmErrShelfDisconnected *NsError
@@ -2145,11 +2172,11 @@ var NsErrorSmEio *NsError
 // NsErrorSmSrepDownstreamOnlineVol enum exports
 var NsErrorSmSrepDownstreamOnlineVol *NsError
 
-// NsErrorSmPoolNoSrcArray enum exports
-var NsErrorSmPoolNoSrcArray *NsError
-
 // NsErrorSmInvalidKeyvalue enum exports
 var NsErrorSmInvalidKeyvalue *NsError
+
+// NsErrorSmPoolNoSrcArray enum exports
+var NsErrorSmPoolNoSrcArray *NsError
 
 // NsErrorSmProtpolMaxLength enum exports
 var NsErrorSmProtpolMaxLength *NsError
@@ -2163,11 +2190,11 @@ var NsErrorSmMissingDiscoveryIp *NsError
 // NsErrorSmReplDeleteReplicaUnsup enum exports
 var NsErrorSmReplDeleteReplicaUnsup *NsError
 
-// NsErrorSmVolSizeDecreased enum exports
-var NsErrorSmVolSizeDecreased *NsError
-
 // NsErrorSmSrepDownstreamAssocedVols enum exports
 var NsErrorSmSrepDownstreamAssocedVols *NsError
+
+// NsErrorSmVolSizeDecreased enum exports
+var NsErrorSmVolSizeDecreased *NsError
 
 // NsErrorSmAddNonfcToFcGroup enum exports
 var NsErrorSmAddNonfcToFcGroup *NsError
@@ -2229,11 +2256,11 @@ var NsErrorSmLimitSnaplun *NsError
 // NsErrorSmIncompatibleCachePolicy enum exports
 var NsErrorSmIncompatibleCachePolicy *NsError
 
-// NsErrorSmVolmvAbortEnospace enum exports
-var NsErrorSmVolmvAbortEnospace *NsError
-
 // NsErrorSmLimitHretSnapGroup enum exports
 var NsErrorSmLimitHretSnapGroup *NsError
+
+// NsErrorSmVolmvAbortEnospace enum exports
+var NsErrorSmVolmvAbortEnospace *NsError
 
 // NsErrorSmVolmvEalready enum exports
 var NsErrorSmVolmvEalready *NsError
@@ -2259,11 +2286,11 @@ var NsErrorSmDuplicateInitiatorWithArgs *NsError
 // NsErrorSmErrShelfForeign enum exports
 var NsErrorSmErrShelfForeign *NsError
 
-// NsErrorSmInvalidAgentType enum exports
-var NsErrorSmInvalidAgentType *NsError
-
 // NsErrorSmEinprogress enum exports
 var NsErrorSmEinprogress *NsError
+
+// NsErrorSmInvalidAgentType enum exports
+var NsErrorSmInvalidAgentType *NsError
 
 // NsErrorSmNotEnoughCache enum exports
 var NsErrorSmNotEnoughCache *NsError
@@ -2310,14 +2337,14 @@ var NsErrorSmReplFanoutMaximumPartnersExceeded *NsError
 // NsErrorSmAsupPingfromCtrlraError enum exports
 var NsErrorSmAsupPingfromCtrlraError *NsError
 
+// NsErrorSmSyncReplConfigure enum exports
+var NsErrorSmSyncReplConfigure *NsError
+
 // NsErrorSmErrShelfInvalidLoc enum exports
 var NsErrorSmErrShelfInvalidLoc *NsError
 
 // NsErrorSmErrShelfSsdDegraded enum exports
 var NsErrorSmErrShelfSsdDegraded *NsError
-
-// NsErrorSmSyncReplConfigure enum exports
-var NsErrorSmSyncReplConfigure *NsError
 
 // NsErrorSmAsupHeartbeatError enum exports
 var NsErrorSmAsupHeartbeatError *NsError
@@ -2346,17 +2373,17 @@ var NsErrorSmProtpolNotSpecified *NsError
 // NsErrorSmUnexpectedQueryParam enum exports
 var NsErrorSmUnexpectedQueryParam *NsError
 
-// NsErrorSmVolmvAbortEalready enum exports
-var NsErrorSmVolmvAbortEalready *NsError
-
 // NsErrorSmFcIntfAlreadyInState enum exports
 var NsErrorSmFcIntfAlreadyInState *NsError
+
+// NsErrorSmIpUpdateNoForce enum exports
+var NsErrorSmIpUpdateNoForce *NsError
 
 // NsErrorSmLimitHretSnapPool enum exports
 var NsErrorSmLimitHretSnapPool *NsError
 
-// NsErrorSmIpUpdateNoForce enum exports
-var NsErrorSmIpUpdateNoForce *NsError
+// NsErrorSmVolmvAbortEalready enum exports
+var NsErrorSmVolmvAbortEalready *NsError
 
 // NsErrorSmSrepAgentTypeMismatchDownstreamVol enum exports
 var NsErrorSmSrepAgentTypeMismatchDownstreamVol *NsError
@@ -2406,11 +2433,11 @@ var NsErrorSmReplObjectBusy *NsError
 // NsErrorSmVolcollOwner enum exports
 var NsErrorSmVolcollOwner *NsError
 
-// NsErrorSmReservedUsername enum exports
-var NsErrorSmReservedUsername *NsError
-
 // NsErrorSmVvolsnapOnline enum exports
 var NsErrorSmVvolsnapOnline *NsError
+
+// NsErrorSmReservedUsername enum exports
+var NsErrorSmReservedUsername *NsError
 
 // NsErrorSmFolderVolmvEinprog enum exports
 var NsErrorSmFolderVolmvEinprog *NsError
@@ -2441,6 +2468,9 @@ var NsErrorSmSrvUpdatePrecheckArray *NsError
 
 // NsErrorSmGatewayNotInSubnets enum exports
 var NsErrorSmGatewayNotInSubnets *NsError
+
+// NsErrorSmErrLdapBindUserNoPassword enum exports
+var NsErrorSmErrLdapBindUserNoPassword *NsError
 
 // NsErrorSmDeprecatedPerfpol enum exports
 var NsErrorSmDeprecatedPerfpol *NsError
@@ -2481,11 +2511,11 @@ var NsErrorSmPoolPartnerPauseUnsup *NsError
 // NsErrorSmNetconfigCreateDraftOnly enum exports
 var NsErrorSmNetconfigCreateDraftOnly *NsError
 
-// NsErrorSmErrArrayNotFound enum exports
-var NsErrorSmErrArrayNotFound *NsError
-
 // NsErrorSmFolsetInUse enum exports
 var NsErrorSmFolsetInUse *NsError
+
+// NsErrorSmErrArrayNotFound enum exports
+var NsErrorSmErrArrayNotFound *NsError
 
 // NsErrorSmErrShelfSesDeviceNotReady enum exports
 var NsErrorSmErrShelfSesDeviceNotReady *NsError
@@ -2520,11 +2550,11 @@ var NsErrorSmAtLeastOneIscsiCluster *NsError
 // NsErrorSmErrTooMany enum exports
 var NsErrorSmErrTooMany *NsError
 
-// NsErrorSmErrShelfExprMfgVerInval enum exports
-var NsErrorSmErrShelfExprMfgVerInval *NsError
-
 // NsErrorSmMgmtIpInvalid enum exports
 var NsErrorSmMgmtIpInvalid *NsError
+
+// NsErrorSmErrShelfExprMfgVerInval enum exports
+var NsErrorSmErrShelfExprMfgVerInval *NsError
 
 // NsErrorSmErrShelfWrongCtrlrSide enum exports
 var NsErrorSmErrShelfWrongCtrlrSide *NsError
@@ -2533,11 +2563,11 @@ func init() {
 	pNsErrorSmReplVolcollDeletion = cNsErrorSmReplVolcollDeletion
 	NsErrorSmReplVolcollDeletion = &pNsErrorSmReplVolcollDeletion
 
-	pNsErrorSmEncryptionGroupCipherOverride = cNsErrorSmEncryptionGroupCipherOverride
-	NsErrorSmEncryptionGroupCipherOverride = &pNsErrorSmEncryptionGroupCipherOverride
-
 	pNsErrorSmEncryptionMustBeEnabled = cNsErrorSmEncryptionMustBeEnabled
 	NsErrorSmEncryptionMustBeEnabled = &pNsErrorSmEncryptionMustBeEnabled
+
+	pNsErrorSmEncryptionGroupCipherOverride = cNsErrorSmEncryptionGroupCipherOverride
+	NsErrorSmEncryptionGroupCipherOverride = &pNsErrorSmEncryptionGroupCipherOverride
 
 	pNsErrorSmExtTrigSchedNotPresent = cNsErrorSmExtTrigSchedNotPresent
 	NsErrorSmExtTrigSchedNotPresent = &pNsErrorSmExtTrigSchedNotPresent
@@ -2550,6 +2580,9 @@ func init() {
 
 	pNsErrorSmArrayPoolMember = cNsErrorSmArrayPoolMember
 	NsErrorSmArrayPoolMember = &pNsErrorSmArrayPoolMember
+
+	pNsErrorSmErrInvalidArg = cNsErrorSmErrInvalidArg
+	NsErrorSmErrInvalidArg = &pNsErrorSmErrInvalidArg
 
 	pNsErrorSmErrShelfCreateRfail = cNsErrorSmErrShelfCreateRfail
 	NsErrorSmErrShelfCreateRfail = &pNsErrorSmErrShelfCreateRfail
@@ -2617,11 +2650,11 @@ func init() {
 	pNsErrorSmVolmvVolEinprog = cNsErrorSmVolmvVolEinprog
 	NsErrorSmVolmvVolEinprog = &pNsErrorSmVolmvVolEinprog
 
-	pNsErrorSmSrepNameConflictVol = cNsErrorSmSrepNameConflictVol
-	NsErrorSmSrepNameConflictVol = &pNsErrorSmSrepNameConflictVol
-
 	pNsErrorSmMultiArrayWithoutAutomaticConnectionMethod = cNsErrorSmMultiArrayWithoutAutomaticConnectionMethod
 	NsErrorSmMultiArrayWithoutAutomaticConnectionMethod = &pNsErrorSmMultiArrayWithoutAutomaticConnectionMethod
+
+	pNsErrorSmSrepNameConflictVol = cNsErrorSmSrepNameConflictVol
+	NsErrorSmSrepNameConflictVol = &pNsErrorSmSrepNameConflictVol
 
 	pNsErrorSmFolderUsageLimitOverPoolCapacity = cNsErrorSmFolderUsageLimitOverPoolCapacity
 	NsErrorSmFolderUsageLimitOverPoolCapacity = &pNsErrorSmFolderUsageLimitOverPoolCapacity
@@ -2631,6 +2664,9 @@ func init() {
 
 	pNsErrorSmErrShelfNotInuse = cNsErrorSmErrShelfNotInuse
 	NsErrorSmErrShelfNotInuse = &pNsErrorSmErrShelfNotInuse
+
+	pNsErrorSmErrLdapAdConflict = cNsErrorSmErrLdapAdConflict
+	NsErrorSmErrLdapAdConflict = &pNsErrorSmErrLdapAdConflict
 
 	pNsErrorSmErrShelfPreactivationMfrErr = cNsErrorSmErrShelfPreactivationMfrErr
 	NsErrorSmErrShelfPreactivationMfrErr = &pNsErrorSmErrShelfPreactivationMfrErr
@@ -2659,11 +2695,11 @@ func init() {
 	pNsErrorSmIncompatibleAppCategory = cNsErrorSmIncompatibleAppCategory
 	NsErrorSmIncompatibleAppCategory = &pNsErrorSmIncompatibleAppCategory
 
-	pNsErrorSmVolmvAbortEnomove = cNsErrorSmVolmvAbortEnomove
-	NsErrorSmVolmvAbortEnomove = &pNsErrorSmVolmvAbortEnomove
-
 	pNsErrorSmLimitSnapRetentionVolcoll = cNsErrorSmLimitSnapRetentionVolcoll
 	NsErrorSmLimitSnapRetentionVolcoll = &pNsErrorSmLimitSnapRetentionVolcoll
+
+	pNsErrorSmVolmvAbortEnomove = cNsErrorSmVolmvAbortEnomove
+	NsErrorSmVolmvAbortEnomove = &pNsErrorSmVolmvAbortEnomove
 
 	pNsErrorSmKeymgrRemove = cNsErrorSmKeymgrRemove
 	NsErrorSmKeymgrRemove = &pNsErrorSmKeymgrRemove
@@ -2677,14 +2713,17 @@ func init() {
 	pNsErrorSmSrepNameConflictVols = cNsErrorSmSrepNameConflictVols
 	NsErrorSmSrepNameConflictVols = &pNsErrorSmSrepNameConflictVols
 
+	pNsErrorSmErrLdapAlreadyExists = cNsErrorSmErrLdapAlreadyExists
+	NsErrorSmErrLdapAlreadyExists = &pNsErrorSmErrLdapAlreadyExists
+
 	pNsErrorSmPoolPartnerResumeUnsup = cNsErrorSmPoolPartnerResumeUnsup
 	NsErrorSmPoolPartnerResumeUnsup = &pNsErrorSmPoolPartnerResumeUnsup
 
-	pNsErrorSmArrayNotFound = cNsErrorSmArrayNotFound
-	NsErrorSmArrayNotFound = &pNsErrorSmArrayNotFound
-
 	pNsErrorSmNoIscsiHardware = cNsErrorSmNoIscsiHardware
 	NsErrorSmNoIscsiHardware = &pNsErrorSmNoIscsiHardware
+
+	pNsErrorSmArrayNotFound = cNsErrorSmArrayNotFound
+	NsErrorSmArrayNotFound = &pNsErrorSmArrayNotFound
 
 	pNsErrorSmEnospc = cNsErrorSmEnospc
 	NsErrorSmEnospc = &pNsErrorSmEnospc
@@ -2725,11 +2764,11 @@ func init() {
 	pNsErrorSmErrPassphraseAuth = cNsErrorSmErrPassphraseAuth
 	NsErrorSmErrPassphraseAuth = &pNsErrorSmErrPassphraseAuth
 
-	pNsErrorSmReplEexist = cNsErrorSmReplEexist
-	NsErrorSmReplEexist = &pNsErrorSmReplEexist
-
 	pNsErrorSmDisableLastProtocol = cNsErrorSmDisableLastProtocol
 	NsErrorSmDisableLastProtocol = &pNsErrorSmDisableLastProtocol
+
+	pNsErrorSmReplEexist = cNsErrorSmReplEexist
+	NsErrorSmReplEexist = &pNsErrorSmReplEexist
 
 	pNsErrorSmSecondUntaggedAssignment = cNsErrorSmSecondUntaggedAssignment
 	NsErrorSmSecondUntaggedAssignment = &pNsErrorSmSecondUntaggedAssignment
@@ -2776,11 +2815,11 @@ func init() {
 	pNsErrorSmEinval = cNsErrorSmEinval
 	NsErrorSmEinval = &pNsErrorSmEinval
 
-	pNsErrorSmNoAssocVols = cNsErrorSmNoAssocVols
-	NsErrorSmNoAssocVols = &pNsErrorSmNoAssocVols
-
 	pNsErrorSmShelfNotInuse = cNsErrorSmShelfNotInuse
 	NsErrorSmShelfNotInuse = &pNsErrorSmShelfNotInuse
+
+	pNsErrorSmNoAssocVols = cNsErrorSmNoAssocVols
+	NsErrorSmNoAssocVols = &pNsErrorSmNoAssocVols
 
 	pNsErrorSmErrProtpolSettingsNotAllowed = cNsErrorSmErrProtpolSettingsNotAllowed
 	NsErrorSmErrProtpolSettingsNotAllowed = &pNsErrorSmErrProtpolSettingsNotAllowed
@@ -2818,11 +2857,11 @@ func init() {
 	pNsErrorSmReplRenameNotsup = cNsErrorSmReplRenameNotsup
 	NsErrorSmReplRenameNotsup = &pNsErrorSmReplRenameNotsup
 
-	pNsErrorSmSessionCreate = cNsErrorSmSessionCreate
-	NsErrorSmSessionCreate = &pNsErrorSmSessionCreate
-
 	pNsErrorSmConflictingAclVol = cNsErrorSmConflictingAclVol
 	NsErrorSmConflictingAclVol = &pNsErrorSmConflictingAclVol
+
+	pNsErrorSmSessionCreate = cNsErrorSmSessionCreate
+	NsErrorSmSessionCreate = &pNsErrorSmSessionCreate
 
 	pNsErrorSmNospace = cNsErrorSmNospace
 	NsErrorSmNospace = &pNsErrorSmNospace
@@ -2866,11 +2905,11 @@ func init() {
 	pNsErrorSmSerialNotAvail = cNsErrorSmSerialNotAvail
 	NsErrorSmSerialNotAvail = &pNsErrorSmSerialNotAvail
 
-	pNsErrorSmErrShelfSesMshipErr = cNsErrorSmErrShelfSesMshipErr
-	NsErrorSmErrShelfSesMshipErr = &pNsErrorSmErrShelfSesMshipErr
-
 	pNsErrorSmFolderProvisionedLimitBelowCurrentUsage = cNsErrorSmFolderProvisionedLimitBelowCurrentUsage
 	NsErrorSmFolderProvisionedLimitBelowCurrentUsage = &pNsErrorSmFolderProvisionedLimitBelowCurrentUsage
+
+	pNsErrorSmErrShelfSesMshipErr = cNsErrorSmErrShelfSesMshipErr
+	NsErrorSmErrShelfSesMshipErr = &pNsErrorSmErrShelfSesMshipErr
 
 	pNsErrorSmPeMultiProtocolAccessNotSupported = cNsErrorSmPeMultiProtocolAccessNotSupported
 	NsErrorSmPeMultiProtocolAccessNotSupported = &pNsErrorSmPeMultiProtocolAccessNotSupported
@@ -2893,14 +2932,14 @@ func init() {
 	pNsErrorSmTooMany = cNsErrorSmTooMany
 	NsErrorSmTooMany = &pNsErrorSmTooMany
 
-	pNsErrorSmErrShelfExprRevIncompatible = cNsErrorSmErrShelfExprRevIncompatible
-	NsErrorSmErrShelfExprRevIncompatible = &pNsErrorSmErrShelfExprRevIncompatible
-
 	pNsErrorSmSrvUnreachable = cNsErrorSmSrvUnreachable
 	NsErrorSmSrvUnreachable = &pNsErrorSmSrvUnreachable
 
 	pNsErrorSmVolumeConflict = cNsErrorSmVolumeConflict
 	NsErrorSmVolumeConflict = &pNsErrorSmVolumeConflict
+
+	pNsErrorSmErrShelfExprRevIncompatible = cNsErrorSmErrShelfExprRevIncompatible
+	NsErrorSmErrShelfExprRevIncompatible = &pNsErrorSmErrShelfExprRevIncompatible
 
 	pNsErrorSmInvalidArrayName = cNsErrorSmInvalidArrayName
 	NsErrorSmInvalidArrayName = &pNsErrorSmInvalidArrayName
@@ -2908,11 +2947,11 @@ func init() {
 	pNsErrorSmCannotReadObject = cNsErrorSmCannotReadObject
 	NsErrorSmCannotReadObject = &pNsErrorSmCannotReadObject
 
-	pNsErrorSmReservedVolName = cNsErrorSmReservedVolName
-	NsErrorSmReservedVolName = &pNsErrorSmReservedVolName
-
 	pNsErrorSmPoolPartnerInUse = cNsErrorSmPoolPartnerInUse
 	NsErrorSmPoolPartnerInUse = &pNsErrorSmPoolPartnerInUse
+
+	pNsErrorSmReservedVolName = cNsErrorSmReservedVolName
+	NsErrorSmReservedVolName = &pNsErrorSmReservedVolName
 
 	pNsErrorSmInvalidInitiatorgrpName = cNsErrorSmInvalidInitiatorgrpName
 	NsErrorSmInvalidInitiatorgrpName = &pNsErrorSmInvalidInitiatorgrpName
@@ -2965,14 +3004,11 @@ func init() {
 	pNsErrorSmMissingCriteriaOperator = cNsErrorSmMissingCriteriaOperator
 	NsErrorSmMissingCriteriaOperator = &pNsErrorSmMissingCriteriaOperator
 
-	pNsErrorSmInvalidAppUuid = cNsErrorSmInvalidAppUuid
-	NsErrorSmInvalidAppUuid = &pNsErrorSmInvalidAppUuid
-
 	pNsErrorSmArrayMemberOrphanWithArgs = cNsErrorSmArrayMemberOrphanWithArgs
 	NsErrorSmArrayMemberOrphanWithArgs = &pNsErrorSmArrayMemberOrphanWithArgs
 
-	pNsErrorSmEmptyVol = cNsErrorSmEmptyVol
-	NsErrorSmEmptyVol = &pNsErrorSmEmptyVol
+	pNsErrorSmInvalidAppUuid = cNsErrorSmInvalidAppUuid
+	NsErrorSmInvalidAppUuid = &pNsErrorSmInvalidAppUuid
 
 	pNsErrorSmDuplicateSubnetLabel = cNsErrorSmDuplicateSubnetLabel
 	NsErrorSmDuplicateSubnetLabel = &pNsErrorSmDuplicateSubnetLabel
@@ -2980,11 +3016,17 @@ func init() {
 	pNsErrorSmZeroVlanIdForTaggedAssignment = cNsErrorSmZeroVlanIdForTaggedAssignment
 	NsErrorSmZeroVlanIdForTaggedAssignment = &pNsErrorSmZeroVlanIdForTaggedAssignment
 
+	pNsErrorSmEmptyVol = cNsErrorSmEmptyVol
+	NsErrorSmEmptyVol = &pNsErrorSmEmptyVol
+
 	pNsErrorSmNoActionFound = cNsErrorSmNoActionFound
 	NsErrorSmNoActionFound = &pNsErrorSmNoActionFound
 
 	pNsErrorSmSyncReplUnconfigureInProgress = cNsErrorSmSyncReplUnconfigureInProgress
 	NsErrorSmSyncReplUnconfigureInProgress = &pNsErrorSmSyncReplUnconfigureInProgress
+
+	pNsErrorSmErrMissingArg = cNsErrorSmErrMissingArg
+	NsErrorSmErrMissingArg = &pNsErrorSmErrMissingArg
 
 	pNsErrorSmVolThickProvMoveInvalid = cNsErrorSmVolThickProvMoveInvalid
 	NsErrorSmVolThickProvMoveInvalid = &pNsErrorSmVolThickProvMoveInvalid
@@ -3010,23 +3052,23 @@ func init() {
 	pNsErrorSmStatsFrequencyInvalid = cNsErrorSmStatsFrequencyInvalid
 	NsErrorSmStatsFrequencyInvalid = &pNsErrorSmStatsFrequencyInvalid
 
-	pNsErrorSmDdupFolderMerge = cNsErrorSmDdupFolderMerge
-	NsErrorSmDdupFolderMerge = &pNsErrorSmDdupFolderMerge
-
 	pNsErrorSmInvalidSubnet = cNsErrorSmInvalidSubnet
 	NsErrorSmInvalidSubnet = &pNsErrorSmInvalidSubnet
 
+	pNsErrorSmDdupFolderMerge = cNsErrorSmDdupFolderMerge
+	NsErrorSmDdupFolderMerge = &pNsErrorSmDdupFolderMerge
+
 	pNsErrorSmReplEnabled = cNsErrorSmReplEnabled
 	NsErrorSmReplEnabled = &pNsErrorSmReplEnabled
-
-	pNsErrorSmPoolPartnerNameConflict = cNsErrorSmPoolPartnerNameConflict
-	NsErrorSmPoolPartnerNameConflict = &pNsErrorSmPoolPartnerNameConflict
 
 	pNsErrorSmAsupPingfromMgmtipError = cNsErrorSmAsupPingfromMgmtipError
 	NsErrorSmAsupPingfromMgmtipError = &pNsErrorSmAsupPingfromMgmtipError
 
 	pNsErrorSmEncryptionGroupScopeOverride = cNsErrorSmEncryptionGroupScopeOverride
 	NsErrorSmEncryptionGroupScopeOverride = &pNsErrorSmEncryptionGroupScopeOverride
+
+	pNsErrorSmPoolPartnerNameConflict = cNsErrorSmPoolPartnerNameConflict
+	NsErrorSmPoolPartnerNameConflict = &pNsErrorSmPoolPartnerNameConflict
 
 	pNsErrorSmErrMaxSessionsReached = cNsErrorSmErrMaxSessionsReached
 	NsErrorSmErrMaxSessionsReached = &pNsErrorSmErrMaxSessionsReached
@@ -3040,11 +3082,11 @@ func init() {
 	pNsErrorSmFolderNeedsLimit = cNsErrorSmFolderNeedsLimit
 	NsErrorSmFolderNeedsLimit = &pNsErrorSmFolderNeedsLimit
 
-	pNsErrorSmVolmvVvol = cNsErrorSmVolmvVvol
-	NsErrorSmVolmvVvol = &pNsErrorSmVolmvVvol
-
 	pNsErrorSmErrGroupMergeInprogress = cNsErrorSmErrGroupMergeInprogress
 	NsErrorSmErrGroupMergeInprogress = &pNsErrorSmErrGroupMergeInprogress
+
+	pNsErrorSmVolmvVvol = cNsErrorSmVolmvVvol
+	NsErrorSmVolmvVvol = &pNsErrorSmVolmvVvol
 
 	pNsErrorSmFolderNotFound = cNsErrorSmFolderNotFound
 	NsErrorSmFolderNotFound = &pNsErrorSmFolderNotFound
@@ -3085,14 +3127,14 @@ func init() {
 	pNsErrorSmProtpolInvalidVssSettings = cNsErrorSmProtpolInvalidVssSettings
 	NsErrorSmProtpolInvalidVssSettings = &pNsErrorSmProtpolInvalidVssSettings
 
+	pNsErrorSmShelfRaidDegraded = cNsErrorSmShelfRaidDegraded
+	NsErrorSmShelfRaidDegraded = &pNsErrorSmShelfRaidDegraded
+
 	pNsErrorSmEncryptionInvalidScope = cNsErrorSmEncryptionInvalidScope
 	NsErrorSmEncryptionInvalidScope = &pNsErrorSmEncryptionInvalidScope
 
 	pNsErrorSmLimitSnapcollVolcoll = cNsErrorSmLimitSnapcollVolcoll
 	NsErrorSmLimitSnapcollVolcoll = &pNsErrorSmLimitSnapcollVolcoll
-
-	pNsErrorSmShelfRaidDegraded = cNsErrorSmShelfRaidDegraded
-	NsErrorSmShelfRaidDegraded = &pNsErrorSmShelfRaidDegraded
 
 	pNsErrorSmInvalidNonIscsiDataSubnetType = cNsErrorSmInvalidNonIscsiDataSubnetType
 	NsErrorSmInvalidNonIscsiDataSubnetType = &pNsErrorSmInvalidNonIscsiDataSubnetType
@@ -3100,11 +3142,11 @@ func init() {
 	pNsErrorSmVolmvIncompatibleAgentType = cNsErrorSmVolmvIncompatibleAgentType
 	NsErrorSmVolmvIncompatibleAgentType = &pNsErrorSmVolmvIncompatibleAgentType
 
-	pNsErrorSmReplPartnerVersionUnknown = cNsErrorSmReplPartnerVersionUnknown
-	NsErrorSmReplPartnerVersionUnknown = &pNsErrorSmReplPartnerVersionUnknown
-
 	pNsErrorSmAsupNameresError = cNsErrorSmAsupNameresError
 	NsErrorSmAsupNameresError = &pNsErrorSmAsupNameresError
+
+	pNsErrorSmReplPartnerVersionUnknown = cNsErrorSmReplPartnerVersionUnknown
+	NsErrorSmReplPartnerVersionUnknown = &pNsErrorSmReplPartnerVersionUnknown
 
 	pNsErrorSmReplApiUnsup = cNsErrorSmReplApiUnsup
 	NsErrorSmReplApiUnsup = &pNsErrorSmReplApiUnsup
@@ -3124,17 +3166,17 @@ func init() {
 	pNsErrorSmReplIntragroup = cNsErrorSmReplIntragroup
 	NsErrorSmReplIntragroup = &pNsErrorSmReplIntragroup
 
-	pNsErrorSmRemoveNonemptyFolder = cNsErrorSmRemoveNonemptyFolder
-	NsErrorSmRemoveNonemptyFolder = &pNsErrorSmRemoveNonemptyFolder
-
 	pNsErrorSmAddNoniscsiToIscsiGroup = cNsErrorSmAddNoniscsiToIscsiGroup
 	NsErrorSmAddNoniscsiToIscsiGroup = &pNsErrorSmAddNoniscsiToIscsiGroup
 
-	pNsErrorSmPoolDedupeIncapable = cNsErrorSmPoolDedupeIncapable
-	NsErrorSmPoolDedupeIncapable = &pNsErrorSmPoolDedupeIncapable
+	pNsErrorSmRemoveNonemptyFolder = cNsErrorSmRemoveNonemptyFolder
+	NsErrorSmRemoveNonemptyFolder = &pNsErrorSmRemoveNonemptyFolder
 
 	pNsErrorSmNoVvolSupport = cNsErrorSmNoVvolSupport
 	NsErrorSmNoVvolSupport = &pNsErrorSmNoVvolSupport
+
+	pNsErrorSmPoolDedupeIncapable = cNsErrorSmPoolDedupeIncapable
+	NsErrorSmPoolDedupeIncapable = &pNsErrorSmPoolDedupeIncapable
 
 	pNsErrorSmNoInitiatorgrp = cNsErrorSmNoInitiatorgrp
 	NsErrorSmNoInitiatorgrp = &pNsErrorSmNoInitiatorgrp
@@ -3145,11 +3187,11 @@ func init() {
 	pNsErrorSmNoDiscoveryIpInManualMode = cNsErrorSmNoDiscoveryIpInManualMode
 	NsErrorSmNoDiscoveryIpInManualMode = &pNsErrorSmNoDiscoveryIpInManualMode
 
-	pNsErrorSmInvalidVolReserveValues = cNsErrorSmInvalidVolReserveValues
-	NsErrorSmInvalidVolReserveValues = &pNsErrorSmInvalidVolReserveValues
-
 	pNsErrorSmSupportIpInvalid = cNsErrorSmSupportIpInvalid
 	NsErrorSmSupportIpInvalid = &pNsErrorSmSupportIpInvalid
+
+	pNsErrorSmInvalidVolReserveValues = cNsErrorSmInvalidVolReserveValues
+	NsErrorSmInvalidVolReserveValues = &pNsErrorSmInvalidVolReserveValues
 
 	pNsErrorSmErrShelfForeignDisk = cNsErrorSmErrShelfForeignDisk
 	NsErrorSmErrShelfForeignDisk = &pNsErrorSmErrShelfForeignDisk
@@ -3223,11 +3265,11 @@ func init() {
 	pNsErrorSmFolderOverdraftLimitNeedsUsageLimit = cNsErrorSmFolderOverdraftLimitNeedsUsageLimit
 	NsErrorSmFolderOverdraftLimitNeedsUsageLimit = &pNsErrorSmFolderOverdraftLimitNeedsUsageLimit
 
-	pNsErrorSmEncryptionMasterKeyMissing = cNsErrorSmEncryptionMasterKeyMissing
-	NsErrorSmEncryptionMasterKeyMissing = &pNsErrorSmEncryptionMasterKeyMissing
-
 	pNsErrorSmSrepAgentTypeMismatchDownstreamVols = cNsErrorSmSrepAgentTypeMismatchDownstreamVols
 	NsErrorSmSrepAgentTypeMismatchDownstreamVols = &pNsErrorSmSrepAgentTypeMismatchDownstreamVols
+
+	pNsErrorSmEncryptionMasterKeyMissing = cNsErrorSmEncryptionMasterKeyMissing
+	NsErrorSmEncryptionMasterKeyMissing = &pNsErrorSmEncryptionMasterKeyMissing
 
 	pNsErrorSmErrVolNotOfflineOnRestore = cNsErrorSmErrVolNotOfflineOnRestore
 	NsErrorSmErrVolNotOfflineOnRestore = &pNsErrorSmErrVolNotOfflineOnRestore
@@ -3247,14 +3289,17 @@ func init() {
 	pNsErrorSmPoolUpdateInvalArrays = cNsErrorSmPoolUpdateInvalArrays
 	NsErrorSmPoolUpdateInvalArrays = &pNsErrorSmPoolUpdateInvalArrays
 
-	pNsErrorSmVolHasOnlineSnap = cNsErrorSmVolHasOnlineSnap
-	NsErrorSmVolHasOnlineSnap = &pNsErrorSmVolHasOnlineSnap
-
 	pNsErrorSmInvalidDataIp = cNsErrorSmInvalidDataIp
 	NsErrorSmInvalidDataIp = &pNsErrorSmInvalidDataIp
 
+	pNsErrorSmVolHasOnlineSnap = cNsErrorSmVolHasOnlineSnap
+	NsErrorSmVolHasOnlineSnap = &pNsErrorSmVolHasOnlineSnap
+
 	pNsErrorSmPoolVolmvEinprog = cNsErrorSmPoolVolmvEinprog
 	NsErrorSmPoolVolmvEinprog = &pNsErrorSmPoolVolmvEinprog
+
+	pNsErrorSmErrLdapBindPasswordNoUser = cNsErrorSmErrLdapBindPasswordNoUser
+	NsErrorSmErrLdapBindPasswordNoUser = &pNsErrorSmErrLdapBindPasswordNoUser
 
 	pNsErrorSmNoDataIpOnMgmtPlusData = cNsErrorSmNoDataIpOnMgmtPlusData
 	NsErrorSmNoDataIpOnMgmtPlusData = &pNsErrorSmNoDataIpOnMgmtPlusData
@@ -3277,11 +3322,11 @@ func init() {
 	pNsErrorSmSnaplunsOutOfSync = cNsErrorSmSnaplunsOutOfSync
 	NsErrorSmSnaplunsOutOfSync = &pNsErrorSmSnaplunsOutOfSync
 
-	pNsErrorSmLimitSnapPool = cNsErrorSmLimitSnapPool
-	NsErrorSmLimitSnapPool = &pNsErrorSmLimitSnapPool
-
 	pNsErrorSmMultiProtocolAccessNotSupported = cNsErrorSmMultiProtocolAccessNotSupported
 	NsErrorSmMultiProtocolAccessNotSupported = &pNsErrorSmMultiProtocolAccessNotSupported
+
+	pNsErrorSmLimitSnapPool = cNsErrorSmLimitSnapPool
+	NsErrorSmLimitSnapPool = &pNsErrorSmLimitSnapPool
 
 	pNsErrorSmVolHasClone = cNsErrorSmVolHasClone
 	NsErrorSmVolHasClone = &pNsErrorSmVolHasClone
@@ -3301,11 +3346,11 @@ func init() {
 	pNsErrorSmMismatchingDuplicateSubnet = cNsErrorSmMismatchingDuplicateSubnet
 	NsErrorSmMismatchingDuplicateSubnet = &pNsErrorSmMismatchingDuplicateSubnet
 
-	pNsErrorSmSrepNotGroupScopedVol = cNsErrorSmSrepNotGroupScopedVol
-	NsErrorSmSrepNotGroupScopedVol = &pNsErrorSmSrepNotGroupScopedVol
-
 	pNsErrorSmOnlyVvolFolderFolset = cNsErrorSmOnlyVvolFolderFolset
 	NsErrorSmOnlyVvolFolderFolset = &pNsErrorSmOnlyVvolFolderFolset
+
+	pNsErrorSmSrepNotGroupScopedVol = cNsErrorSmSrepNotGroupScopedVol
+	NsErrorSmSrepNotGroupScopedVol = &pNsErrorSmSrepNotGroupScopedVol
 
 	pNsErrorSmReplSnapshotSync = cNsErrorSmReplSnapshotSync
 	NsErrorSmReplSnapshotSync = &pNsErrorSmReplSnapshotSync
@@ -3316,20 +3361,20 @@ func init() {
 	pNsErrorSmDefaultRouteMissing = cNsErrorSmDefaultRouteMissing
 	NsErrorSmDefaultRouteMissing = &pNsErrorSmDefaultRouteMissing
 
-	pNsErrorSmReplVasa3ApiUnsup = cNsErrorSmReplVasa3ApiUnsup
-	NsErrorSmReplVasa3ApiUnsup = &pNsErrorSmReplVasa3ApiUnsup
-
 	pNsErrorSmOverlappingSubnets = cNsErrorSmOverlappingSubnets
 	NsErrorSmOverlappingSubnets = &pNsErrorSmOverlappingSubnets
+
+	pNsErrorSmReplVasa3ApiUnsup = cNsErrorSmReplVasa3ApiUnsup
+	NsErrorSmReplVasa3ApiUnsup = &pNsErrorSmReplVasa3ApiUnsup
 
 	pNsErrorSmMissingArg = cNsErrorSmMissingArg
 	NsErrorSmMissingArg = &pNsErrorSmMissingArg
 
-	pNsErrorSmVolmvCachePinDedupeNotsupp = cNsErrorSmVolmvCachePinDedupeNotsupp
-	NsErrorSmVolmvCachePinDedupeNotsupp = &pNsErrorSmVolmvCachePinDedupeNotsupp
-
 	pNsErrorSmErrMergeConflict = cNsErrorSmErrMergeConflict
 	NsErrorSmErrMergeConflict = &pNsErrorSmErrMergeConflict
+
+	pNsErrorSmVolmvCachePinDedupeNotsupp = cNsErrorSmVolmvCachePinDedupeNotsupp
+	NsErrorSmVolmvCachePinDedupeNotsupp = &pNsErrorSmVolmvCachePinDedupeNotsupp
 
 	pNsErrorSmTooSmall = cNsErrorSmTooSmall
 	NsErrorSmTooSmall = &pNsErrorSmTooSmall
@@ -3346,11 +3391,11 @@ func init() {
 	pNsErrorSmLunMismatch = cNsErrorSmLunMismatch
 	NsErrorSmLunMismatch = &pNsErrorSmLunMismatch
 
-	pNsErrorSmErrShelfInvalidDiskCount = cNsErrorSmErrShelfInvalidDiskCount
-	NsErrorSmErrShelfInvalidDiskCount = &pNsErrorSmErrShelfInvalidDiskCount
-
 	pNsErrorSmLimitVolacl = cNsErrorSmLimitVolacl
 	NsErrorSmLimitVolacl = &pNsErrorSmLimitVolacl
+
+	pNsErrorSmErrShelfInvalidDiskCount = cNsErrorSmErrShelfInvalidDiskCount
+	NsErrorSmErrShelfInvalidDiskCount = &pNsErrorSmErrShelfInvalidDiskCount
 
 	pNsErrorSmControllerNotActive = cNsErrorSmControllerNotActive
 	NsErrorSmControllerNotActive = &pNsErrorSmControllerNotActive
@@ -3358,11 +3403,11 @@ func init() {
 	pNsErrorSmReplNoPartnerAvail = cNsErrorSmReplNoPartnerAvail
 	NsErrorSmReplNoPartnerAvail = &pNsErrorSmReplNoPartnerAvail
 
-	pNsErrorSmSreplMgmtOpDisallowedWhenSolo = cNsErrorSmSreplMgmtOpDisallowedWhenSolo
-	NsErrorSmSreplMgmtOpDisallowedWhenSolo = &pNsErrorSmSreplMgmtOpDisallowedWhenSolo
-
 	pNsErrorSmNoMgmtSubnetSpecified = cNsErrorSmNoMgmtSubnetSpecified
 	NsErrorSmNoMgmtSubnetSpecified = &pNsErrorSmNoMgmtSubnetSpecified
+
+	pNsErrorSmSreplMgmtOpDisallowedWhenSolo = cNsErrorSmSreplMgmtOpDisallowedWhenSolo
+	NsErrorSmSreplMgmtOpDisallowedWhenSolo = &pNsErrorSmSreplMgmtOpDisallowedWhenSolo
 
 	pNsErrorSmFolderConflict = cNsErrorSmFolderConflict
 	NsErrorSmFolderConflict = &pNsErrorSmFolderConflict
@@ -3391,11 +3436,11 @@ func init() {
 	pNsErrorSmNoAvailableLun = cNsErrorSmNoAvailableLun
 	NsErrorSmNoAvailableLun = &pNsErrorSmNoAvailableLun
 
-	pNsErrorSmGroupPartnerNameConflict = cNsErrorSmGroupPartnerNameConflict
-	NsErrorSmGroupPartnerNameConflict = &pNsErrorSmGroupPartnerNameConflict
-
 	pNsErrorSmMgmtIpNotOnMgmt = cNsErrorSmMgmtIpNotOnMgmt
 	NsErrorSmMgmtIpNotOnMgmt = &pNsErrorSmMgmtIpNotOnMgmt
+
+	pNsErrorSmGroupPartnerNameConflict = cNsErrorSmGroupPartnerNameConflict
+	NsErrorSmGroupPartnerNameConflict = &pNsErrorSmGroupPartnerNameConflict
 
 	pNsErrorSmInUseLun = cNsErrorSmInUseLun
 	NsErrorSmInUseLun = &pNsErrorSmInUseLun
@@ -3418,11 +3463,11 @@ func init() {
 	pNsErrorSmErrShelfConnectedOnlyOneSide = cNsErrorSmErrShelfConnectedOnlyOneSide
 	NsErrorSmErrShelfConnectedOnlyOneSide = &pNsErrorSmErrShelfConnectedOnlyOneSide
 
-	pNsErrorSmVolmvEnospace = cNsErrorSmVolmvEnospace
-	NsErrorSmVolmvEnospace = &pNsErrorSmVolmvEnospace
-
 	pNsErrorSmIncompatibleVolumes = cNsErrorSmIncompatibleVolumes
 	NsErrorSmIncompatibleVolumes = &pNsErrorSmIncompatibleVolumes
+
+	pNsErrorSmVolmvEnospace = cNsErrorSmVolmvEnospace
+	NsErrorSmVolmvEnospace = &pNsErrorSmVolmvEnospace
 
 	pNsErrorSmComplexTypeQueryParam = cNsErrorSmComplexTypeQueryParam
 	NsErrorSmComplexTypeQueryParam = &pNsErrorSmComplexTypeQueryParam
@@ -3439,11 +3484,11 @@ func init() {
 	pNsErrorSmInvalidPathVariable = cNsErrorSmInvalidPathVariable
 	NsErrorSmInvalidPathVariable = &pNsErrorSmInvalidPathVariable
 
-	pNsErrorSmErrArgChangeNotAllowed = cNsErrorSmErrArgChangeNotAllowed
-	NsErrorSmErrArgChangeNotAllowed = &pNsErrorSmErrArgChangeNotAllowed
-
 	pNsErrorSmSpecifiedSnapshotLun = cNsErrorSmSpecifiedSnapshotLun
 	NsErrorSmSpecifiedSnapshotLun = &pNsErrorSmSpecifiedSnapshotLun
+
+	pNsErrorSmErrArgChangeNotAllowed = cNsErrorSmErrArgChangeNotAllowed
+	NsErrorSmErrArgChangeNotAllowed = &pNsErrorSmErrArgChangeNotAllowed
 
 	pNsErrorSmSrepDownstreamAssocedVol = cNsErrorSmSrepDownstreamAssocedVol
 	NsErrorSmSrepDownstreamAssocedVol = &pNsErrorSmSrepDownstreamAssocedVol
@@ -3469,14 +3514,14 @@ func init() {
 	pNsErrorSmSrvUpdatePrecheck = cNsErrorSmSrvUpdatePrecheck
 	NsErrorSmSrvUpdatePrecheck = &pNsErrorSmSrvUpdatePrecheck
 
-	pNsErrorSmVolDedupeEncryptionInvalid = cNsErrorSmVolDedupeEncryptionInvalid
-	NsErrorSmVolDedupeEncryptionInvalid = &pNsErrorSmVolDedupeEncryptionInvalid
+	pNsErrorSmHttpConflict = cNsErrorSmHttpConflict
+	NsErrorSmHttpConflict = &pNsErrorSmHttpConflict
 
 	pNsErrorSmVvolFolderNoAppsrvr = cNsErrorSmVvolFolderNoAppsrvr
 	NsErrorSmVvolFolderNoAppsrvr = &pNsErrorSmVvolFolderNoAppsrvr
 
-	pNsErrorSmHttpConflict = cNsErrorSmHttpConflict
-	NsErrorSmHttpConflict = &pNsErrorSmHttpConflict
+	pNsErrorSmVolDedupeEncryptionInvalid = cNsErrorSmVolDedupeEncryptionInvalid
+	NsErrorSmVolDedupeEncryptionInvalid = &pNsErrorSmVolDedupeEncryptionInvalid
 
 	pNsErrorSmArrayRenameInNetconfigFailed = cNsErrorSmArrayRenameInNetconfigFailed
 	NsErrorSmArrayRenameInNetconfigFailed = &pNsErrorSmArrayRenameInNetconfigFailed
@@ -3496,35 +3541,35 @@ func init() {
 	pNsErrorSmErrGroupMergeBusy = cNsErrorSmErrGroupMergeBusy
 	NsErrorSmErrGroupMergeBusy = &pNsErrorSmErrGroupMergeBusy
 
-	pNsErrorSmErrVolmvPoolMerging = cNsErrorSmErrVolmvPoolMerging
-	NsErrorSmErrVolmvPoolMerging = &pNsErrorSmErrVolmvPoolMerging
-
 	pNsErrorSmArrayNotFoundWithArgs = cNsErrorSmArrayNotFoundWithArgs
 	NsErrorSmArrayNotFoundWithArgs = &pNsErrorSmArrayNotFoundWithArgs
 
 	pNsErrorSmConnectionRebalancingWithoutAutomaticMethod = cNsErrorSmConnectionRebalancingWithoutAutomaticMethod
 	NsErrorSmConnectionRebalancingWithoutAutomaticMethod = &pNsErrorSmConnectionRebalancingWithoutAutomaticMethod
 
+	pNsErrorSmErrVolmvPoolMerging = cNsErrorSmErrVolmvPoolMerging
+	NsErrorSmErrVolmvPoolMerging = &pNsErrorSmErrVolmvPoolMerging
+
 	pNsErrorSmSrepDownstreamNoCommonSnapVols = cNsErrorSmSrepDownstreamNoCommonSnapVols
 	NsErrorSmSrepDownstreamNoCommonSnapVols = &pNsErrorSmSrepDownstreamNoCommonSnapVols
-
-	pNsErrorSmErrShelfWrongSasPort = cNsErrorSmErrShelfWrongSasPort
-	NsErrorSmErrShelfWrongSasPort = &pNsErrorSmErrShelfWrongSasPort
 
 	pNsErrorSmFolderUsageLimitBelowCurrentUsage = cNsErrorSmFolderUsageLimitBelowCurrentUsage
 	NsErrorSmFolderUsageLimitBelowCurrentUsage = &pNsErrorSmFolderUsageLimitBelowCurrentUsage
 
+	pNsErrorSmErrShelfWrongSasPort = cNsErrorSmErrShelfWrongSasPort
+	NsErrorSmErrShelfWrongSasPort = &pNsErrorSmErrShelfWrongSasPort
+
 	pNsErrorSmLimitSnapRetentionPool = cNsErrorSmLimitSnapRetentionPool
 	NsErrorSmLimitSnapRetentionPool = &pNsErrorSmLimitSnapRetentionPool
+
+	pNsErrorSmSrepNotGroupScopedVols = cNsErrorSmSrepNotGroupScopedVols
+	NsErrorSmSrepNotGroupScopedVols = &pNsErrorSmSrepNotGroupScopedVols
 
 	pNsErrorSmErrShelfExprFwVerInval = cNsErrorSmErrShelfExprFwVerInval
 	NsErrorSmErrShelfExprFwVerInval = &pNsErrorSmErrShelfExprFwVerInval
 
 	pNsErrorSmSrepVolcollUnsup = cNsErrorSmSrepVolcollUnsup
 	NsErrorSmSrepVolcollUnsup = &pNsErrorSmSrepVolcollUnsup
-
-	pNsErrorSmSrepNotGroupScopedVols = cNsErrorSmSrepNotGroupScopedVols
-	NsErrorSmSrepNotGroupScopedVols = &pNsErrorSmSrepNotGroupScopedVols
 
 	pNsErrorSmFcIntfNotFound = cNsErrorSmFcIntfNotFound
 	NsErrorSmFcIntfNotFound = &pNsErrorSmFcIntfNotFound
@@ -3538,17 +3583,17 @@ func init() {
 	pNsErrorSmAppserverInUse = cNsErrorSmAppserverInUse
 	NsErrorSmAppserverInUse = &pNsErrorSmAppserverInUse
 
-	pNsErrorSmPoolDoesNotHaveFolder = cNsErrorSmPoolDoesNotHaveFolder
-	NsErrorSmPoolDoesNotHaveFolder = &pNsErrorSmPoolDoesNotHaveFolder
-
 	pNsErrorSmPerfpolNotFound = cNsErrorSmPerfpolNotFound
 	NsErrorSmPerfpolNotFound = &pNsErrorSmPerfpolNotFound
+
+	pNsErrorSmDuplicateInitiator = cNsErrorSmDuplicateInitiator
+	NsErrorSmDuplicateInitiator = &pNsErrorSmDuplicateInitiator
 
 	pNsErrorSmPerfpolOob = cNsErrorSmPerfpolOob
 	NsErrorSmPerfpolOob = &pNsErrorSmPerfpolOob
 
-	pNsErrorSmDuplicateInitiator = cNsErrorSmDuplicateInitiator
-	NsErrorSmDuplicateInitiator = &pNsErrorSmDuplicateInitiator
+	pNsErrorSmPoolDoesNotHaveFolder = cNsErrorSmPoolDoesNotHaveFolder
+	NsErrorSmPoolDoesNotHaveFolder = &pNsErrorSmPoolDoesNotHaveFolder
 
 	pNsErrorSmInUseAppUuid = cNsErrorSmInUseAppUuid
 	NsErrorSmInUseAppUuid = &pNsErrorSmInUseAppUuid
@@ -3571,11 +3616,11 @@ func init() {
 	pNsErrorSmErrReplCantConnect = cNsErrorSmErrReplCantConnect
 	NsErrorSmErrReplCantConnect = &pNsErrorSmErrReplCantConnect
 
-	pNsErrorSmErrShelfExpanderErr = cNsErrorSmErrShelfExpanderErr
-	NsErrorSmErrShelfExpanderErr = &pNsErrorSmErrShelfExpanderErr
-
 	pNsErrorSmPeFailAclRemoval = cNsErrorSmPeFailAclRemoval
 	NsErrorSmPeFailAclRemoval = &pNsErrorSmPeFailAclRemoval
+
+	pNsErrorSmErrShelfExpanderErr = cNsErrorSmErrShelfExpanderErr
+	NsErrorSmErrShelfExpanderErr = &pNsErrorSmErrShelfExpanderErr
 
 	pNsErrorSmSupportIpNotOnMgmt = cNsErrorSmSupportIpNotOnMgmt
 	NsErrorSmSupportIpNotOnMgmt = &pNsErrorSmSupportIpNotOnMgmt
@@ -3592,14 +3637,14 @@ func init() {
 	pNsErrorSmLimitVolmvHretSnapPool = cNsErrorSmLimitVolmvHretSnapPool
 	NsErrorSmLimitVolmvHretSnapPool = &pNsErrorSmLimitVolmvHretSnapPool
 
+	pNsErrorSmDataIpNotOnSubnet = cNsErrorSmDataIpNotOnSubnet
+	NsErrorSmDataIpNotOnSubnet = &pNsErrorSmDataIpNotOnSubnet
+
 	pNsErrorSmStartTimeBeyondEndTime = cNsErrorSmStartTimeBeyondEndTime
 	NsErrorSmStartTimeBeyondEndTime = &pNsErrorSmStartTimeBeyondEndTime
 
 	pNsErrorSmReplRemotePaused = cNsErrorSmReplRemotePaused
 	NsErrorSmReplRemotePaused = &pNsErrorSmReplRemotePaused
-
-	pNsErrorSmDataIpNotOnSubnet = cNsErrorSmDataIpNotOnSubnet
-	NsErrorSmDataIpNotOnSubnet = &pNsErrorSmDataIpNotOnSubnet
 
 	pNsErrorSmConflictingInitiatorAlias = cNsErrorSmConflictingInitiatorAlias
 	NsErrorSmConflictingInitiatorAlias = &pNsErrorSmConflictingInitiatorAlias
@@ -3613,11 +3658,11 @@ func init() {
 	pNsErrorSmQosLimitNotInRange = cNsErrorSmQosLimitNotInRange
 	NsErrorSmQosLimitNotInRange = &pNsErrorSmQosLimitNotInRange
 
-	pNsErrorSmErrShelfNoRserial = cNsErrorSmErrShelfNoRserial
-	NsErrorSmErrShelfNoRserial = &pNsErrorSmErrShelfNoRserial
-
 	pNsErrorSmUntaggedMtuNotLargest = cNsErrorSmUntaggedMtuNotLargest
 	NsErrorSmUntaggedMtuNotLargest = &pNsErrorSmUntaggedMtuNotLargest
+
+	pNsErrorSmErrShelfNoRserial = cNsErrorSmErrShelfNoRserial
+	NsErrorSmErrShelfNoRserial = &pNsErrorSmErrShelfNoRserial
 
 	pNsErrorSmErrShelfDisconnected = cNsErrorSmErrShelfDisconnected
 	NsErrorSmErrShelfDisconnected = &pNsErrorSmErrShelfDisconnected
@@ -3658,11 +3703,11 @@ func init() {
 	pNsErrorSmSrepDownstreamOnlineVol = cNsErrorSmSrepDownstreamOnlineVol
 	NsErrorSmSrepDownstreamOnlineVol = &pNsErrorSmSrepDownstreamOnlineVol
 
-	pNsErrorSmPoolNoSrcArray = cNsErrorSmPoolNoSrcArray
-	NsErrorSmPoolNoSrcArray = &pNsErrorSmPoolNoSrcArray
-
 	pNsErrorSmInvalidKeyvalue = cNsErrorSmInvalidKeyvalue
 	NsErrorSmInvalidKeyvalue = &pNsErrorSmInvalidKeyvalue
+
+	pNsErrorSmPoolNoSrcArray = cNsErrorSmPoolNoSrcArray
+	NsErrorSmPoolNoSrcArray = &pNsErrorSmPoolNoSrcArray
 
 	pNsErrorSmProtpolMaxLength = cNsErrorSmProtpolMaxLength
 	NsErrorSmProtpolMaxLength = &pNsErrorSmProtpolMaxLength
@@ -3676,11 +3721,11 @@ func init() {
 	pNsErrorSmReplDeleteReplicaUnsup = cNsErrorSmReplDeleteReplicaUnsup
 	NsErrorSmReplDeleteReplicaUnsup = &pNsErrorSmReplDeleteReplicaUnsup
 
-	pNsErrorSmVolSizeDecreased = cNsErrorSmVolSizeDecreased
-	NsErrorSmVolSizeDecreased = &pNsErrorSmVolSizeDecreased
-
 	pNsErrorSmSrepDownstreamAssocedVols = cNsErrorSmSrepDownstreamAssocedVols
 	NsErrorSmSrepDownstreamAssocedVols = &pNsErrorSmSrepDownstreamAssocedVols
+
+	pNsErrorSmVolSizeDecreased = cNsErrorSmVolSizeDecreased
+	NsErrorSmVolSizeDecreased = &pNsErrorSmVolSizeDecreased
 
 	pNsErrorSmAddNonfcToFcGroup = cNsErrorSmAddNonfcToFcGroup
 	NsErrorSmAddNonfcToFcGroup = &pNsErrorSmAddNonfcToFcGroup
@@ -3742,11 +3787,11 @@ func init() {
 	pNsErrorSmIncompatibleCachePolicy = cNsErrorSmIncompatibleCachePolicy
 	NsErrorSmIncompatibleCachePolicy = &pNsErrorSmIncompatibleCachePolicy
 
-	pNsErrorSmVolmvAbortEnospace = cNsErrorSmVolmvAbortEnospace
-	NsErrorSmVolmvAbortEnospace = &pNsErrorSmVolmvAbortEnospace
-
 	pNsErrorSmLimitHretSnapGroup = cNsErrorSmLimitHretSnapGroup
 	NsErrorSmLimitHretSnapGroup = &pNsErrorSmLimitHretSnapGroup
+
+	pNsErrorSmVolmvAbortEnospace = cNsErrorSmVolmvAbortEnospace
+	NsErrorSmVolmvAbortEnospace = &pNsErrorSmVolmvAbortEnospace
 
 	pNsErrorSmVolmvEalready = cNsErrorSmVolmvEalready
 	NsErrorSmVolmvEalready = &pNsErrorSmVolmvEalready
@@ -3772,11 +3817,11 @@ func init() {
 	pNsErrorSmErrShelfForeign = cNsErrorSmErrShelfForeign
 	NsErrorSmErrShelfForeign = &pNsErrorSmErrShelfForeign
 
-	pNsErrorSmInvalidAgentType = cNsErrorSmInvalidAgentType
-	NsErrorSmInvalidAgentType = &pNsErrorSmInvalidAgentType
-
 	pNsErrorSmEinprogress = cNsErrorSmEinprogress
 	NsErrorSmEinprogress = &pNsErrorSmEinprogress
+
+	pNsErrorSmInvalidAgentType = cNsErrorSmInvalidAgentType
+	NsErrorSmInvalidAgentType = &pNsErrorSmInvalidAgentType
 
 	pNsErrorSmNotEnoughCache = cNsErrorSmNotEnoughCache
 	NsErrorSmNotEnoughCache = &pNsErrorSmNotEnoughCache
@@ -3823,14 +3868,14 @@ func init() {
 	pNsErrorSmAsupPingfromCtrlraError = cNsErrorSmAsupPingfromCtrlraError
 	NsErrorSmAsupPingfromCtrlraError = &pNsErrorSmAsupPingfromCtrlraError
 
+	pNsErrorSmSyncReplConfigure = cNsErrorSmSyncReplConfigure
+	NsErrorSmSyncReplConfigure = &pNsErrorSmSyncReplConfigure
+
 	pNsErrorSmErrShelfInvalidLoc = cNsErrorSmErrShelfInvalidLoc
 	NsErrorSmErrShelfInvalidLoc = &pNsErrorSmErrShelfInvalidLoc
 
 	pNsErrorSmErrShelfSsdDegraded = cNsErrorSmErrShelfSsdDegraded
 	NsErrorSmErrShelfSsdDegraded = &pNsErrorSmErrShelfSsdDegraded
-
-	pNsErrorSmSyncReplConfigure = cNsErrorSmSyncReplConfigure
-	NsErrorSmSyncReplConfigure = &pNsErrorSmSyncReplConfigure
 
 	pNsErrorSmAsupHeartbeatError = cNsErrorSmAsupHeartbeatError
 	NsErrorSmAsupHeartbeatError = &pNsErrorSmAsupHeartbeatError
@@ -3859,17 +3904,17 @@ func init() {
 	pNsErrorSmUnexpectedQueryParam = cNsErrorSmUnexpectedQueryParam
 	NsErrorSmUnexpectedQueryParam = &pNsErrorSmUnexpectedQueryParam
 
-	pNsErrorSmVolmvAbortEalready = cNsErrorSmVolmvAbortEalready
-	NsErrorSmVolmvAbortEalready = &pNsErrorSmVolmvAbortEalready
-
 	pNsErrorSmFcIntfAlreadyInState = cNsErrorSmFcIntfAlreadyInState
 	NsErrorSmFcIntfAlreadyInState = &pNsErrorSmFcIntfAlreadyInState
+
+	pNsErrorSmIpUpdateNoForce = cNsErrorSmIpUpdateNoForce
+	NsErrorSmIpUpdateNoForce = &pNsErrorSmIpUpdateNoForce
 
 	pNsErrorSmLimitHretSnapPool = cNsErrorSmLimitHretSnapPool
 	NsErrorSmLimitHretSnapPool = &pNsErrorSmLimitHretSnapPool
 
-	pNsErrorSmIpUpdateNoForce = cNsErrorSmIpUpdateNoForce
-	NsErrorSmIpUpdateNoForce = &pNsErrorSmIpUpdateNoForce
+	pNsErrorSmVolmvAbortEalready = cNsErrorSmVolmvAbortEalready
+	NsErrorSmVolmvAbortEalready = &pNsErrorSmVolmvAbortEalready
 
 	pNsErrorSmSrepAgentTypeMismatchDownstreamVol = cNsErrorSmSrepAgentTypeMismatchDownstreamVol
 	NsErrorSmSrepAgentTypeMismatchDownstreamVol = &pNsErrorSmSrepAgentTypeMismatchDownstreamVol
@@ -3919,11 +3964,11 @@ func init() {
 	pNsErrorSmVolcollOwner = cNsErrorSmVolcollOwner
 	NsErrorSmVolcollOwner = &pNsErrorSmVolcollOwner
 
-	pNsErrorSmReservedUsername = cNsErrorSmReservedUsername
-	NsErrorSmReservedUsername = &pNsErrorSmReservedUsername
-
 	pNsErrorSmVvolsnapOnline = cNsErrorSmVvolsnapOnline
 	NsErrorSmVvolsnapOnline = &pNsErrorSmVvolsnapOnline
+
+	pNsErrorSmReservedUsername = cNsErrorSmReservedUsername
+	NsErrorSmReservedUsername = &pNsErrorSmReservedUsername
 
 	pNsErrorSmFolderVolmvEinprog = cNsErrorSmFolderVolmvEinprog
 	NsErrorSmFolderVolmvEinprog = &pNsErrorSmFolderVolmvEinprog
@@ -3954,6 +3999,9 @@ func init() {
 
 	pNsErrorSmGatewayNotInSubnets = cNsErrorSmGatewayNotInSubnets
 	NsErrorSmGatewayNotInSubnets = &pNsErrorSmGatewayNotInSubnets
+
+	pNsErrorSmErrLdapBindUserNoPassword = cNsErrorSmErrLdapBindUserNoPassword
+	NsErrorSmErrLdapBindUserNoPassword = &pNsErrorSmErrLdapBindUserNoPassword
 
 	pNsErrorSmDeprecatedPerfpol = cNsErrorSmDeprecatedPerfpol
 	NsErrorSmDeprecatedPerfpol = &pNsErrorSmDeprecatedPerfpol
@@ -3994,11 +4042,11 @@ func init() {
 	pNsErrorSmNetconfigCreateDraftOnly = cNsErrorSmNetconfigCreateDraftOnly
 	NsErrorSmNetconfigCreateDraftOnly = &pNsErrorSmNetconfigCreateDraftOnly
 
-	pNsErrorSmErrArrayNotFound = cNsErrorSmErrArrayNotFound
-	NsErrorSmErrArrayNotFound = &pNsErrorSmErrArrayNotFound
-
 	pNsErrorSmFolsetInUse = cNsErrorSmFolsetInUse
 	NsErrorSmFolsetInUse = &pNsErrorSmFolsetInUse
+
+	pNsErrorSmErrArrayNotFound = cNsErrorSmErrArrayNotFound
+	NsErrorSmErrArrayNotFound = &pNsErrorSmErrArrayNotFound
 
 	pNsErrorSmErrShelfSesDeviceNotReady = cNsErrorSmErrShelfSesDeviceNotReady
 	NsErrorSmErrShelfSesDeviceNotReady = &pNsErrorSmErrShelfSesDeviceNotReady
@@ -4033,11 +4081,11 @@ func init() {
 	pNsErrorSmErrTooMany = cNsErrorSmErrTooMany
 	NsErrorSmErrTooMany = &pNsErrorSmErrTooMany
 
-	pNsErrorSmErrShelfExprMfgVerInval = cNsErrorSmErrShelfExprMfgVerInval
-	NsErrorSmErrShelfExprMfgVerInval = &pNsErrorSmErrShelfExprMfgVerInval
-
 	pNsErrorSmMgmtIpInvalid = cNsErrorSmMgmtIpInvalid
 	NsErrorSmMgmtIpInvalid = &pNsErrorSmMgmtIpInvalid
+
+	pNsErrorSmErrShelfExprMfgVerInval = cNsErrorSmErrShelfExprMfgVerInval
+	NsErrorSmErrShelfExprMfgVerInval = &pNsErrorSmErrShelfExprMfgVerInval
 
 	pNsErrorSmErrShelfWrongCtrlrSide = cNsErrorSmErrShelfWrongCtrlrSide
 	NsErrorSmErrShelfWrongCtrlrSide = &pNsErrorSmErrShelfWrongCtrlrSide

--- a/pkg/client/v1/nimbleos/ns_token_report_user_details_return.go
+++ b/pkg/client/v1/nimbleos/ns_token_report_user_details_return.go
@@ -23,11 +23,11 @@ func init() {
 type NsTokenReportUserDetailsReturn struct {
 	// UserName - User name for the session.
 	UserName *string `json:"user_name,omitempty"`
-	// PrimaryGroupId - The ID of the primary Active Directory user group the user belongs to. RBAC is granted based on this group.
+	// PrimaryGroupId - The ID of the primary directory service user group the user belongs to. RBAC is granted based on this group.
 	PrimaryGroupId *string `json:"primary_group_id,omitempty"`
-	// PrimaryGroupName - The primary Active Directory user group the user belongs to. RBAC is granted based on this group.
+	// PrimaryGroupName - The primary directory user group the user belongs to. RBAC is granted based on this group.
 	PrimaryGroupName *string `json:"primary_group_name,omitempty"`
-	// GroupCount - The number of Active Directory user groups the user belongs to.
+	// GroupCount - The number of directory service user groups the user belongs to.
 	GroupCount *int64 `json:"group_count,omitempty"`
 	// Role - Role of the user.
 	Role *NsUserRoles `json:"role,omitempty"`
@@ -35,6 +35,8 @@ type NsTokenReportUserDetailsReturn struct {
 	InactivityTimeout *int64 `json:"inactivity_timeout,omitempty"`
 	// UserId - Global ID of the user.
 	UserId *string `json:"user_id,omitempty"`
-	// Groups - The list of Active Directory groups the user belongs to.
+	// DomainType - Connected directory service type. Either 'ad, 'ldap' or 'local'.
+	DomainType *NsDomainType `json:"domain_type,omitempty"`
+	// Groups - The list of directory service groups the user belongs to.
 	Groups []*string `json:"groups,omitempty"`
 }

--- a/pkg/client/v1/nimbleos/protection_schedule.go
+++ b/pkg/client/v1/nimbleos/protection_schedule.go
@@ -21,22 +21,24 @@ func init() {
 	LastReplicatedSnapcollIdfield := "last_replicated_snapcoll_id"
 	SchedOwnerIdfield := "sched_owner_id"
 	SchedOwnerNamefield := "sched_owner_name"
+	CurrentlyReplicatingSnapcollNamefield := "currently_replicating_snapcoll_name"
 
 	ProtectionScheduleFields = &ProtectionSchedule{
-		ID:                         &IDfield,
-		Name:                       &Namefield,
-		Description:                &Descriptionfield,
-		VolcollOrProttmplId:        &VolcollOrProttmplIdfield,
-		Days:                       &Daysfield,
-		DownstreamPartner:          &DownstreamPartnerfield,
-		DownstreamPartnerName:      &DownstreamPartnerNamefield,
-		DownstreamPartnerId:        &DownstreamPartnerIdfield,
-		UpstreamPartnerName:        &UpstreamPartnerNamefield,
-		UpstreamPartnerId:          &UpstreamPartnerIdfield,
-		LastReplicatedSnapcollName: &LastReplicatedSnapcollNamefield,
-		LastReplicatedSnapcollId:   &LastReplicatedSnapcollIdfield,
-		SchedOwnerId:               &SchedOwnerIdfield,
-		SchedOwnerName:             &SchedOwnerNamefield,
+		ID:                               &IDfield,
+		Name:                             &Namefield,
+		Description:                      &Descriptionfield,
+		VolcollOrProttmplId:              &VolcollOrProttmplIdfield,
+		Days:                             &Daysfield,
+		DownstreamPartner:                &DownstreamPartnerfield,
+		DownstreamPartnerName:            &DownstreamPartnerNamefield,
+		DownstreamPartnerId:              &DownstreamPartnerIdfield,
+		UpstreamPartnerName:              &UpstreamPartnerNamefield,
+		UpstreamPartnerId:                &UpstreamPartnerIdfield,
+		LastReplicatedSnapcollName:       &LastReplicatedSnapcollNamefield,
+		LastReplicatedSnapcollId:         &LastReplicatedSnapcollIdfield,
+		SchedOwnerId:                     &SchedOwnerIdfield,
+		SchedOwnerName:                   &SchedOwnerNamefield,
+		CurrentlyReplicatingSnapcollName: &CurrentlyReplicatingSnapcollNamefield,
 	}
 }
 
@@ -115,6 +117,8 @@ type ProtectionSchedule struct {
 	SchedOwnerName *string `json:"sched_owner_name,omitempty"`
 	// LastConfigChangeTime - The last timing configutation changed.
 	LastConfigChangeTime *int64 `json:"last_config_change_time,omitempty"`
+	// CurrentlyReplicatingSnapcollName - The name of the currently replicating snapshot collection if one exists, the empty string otherwise.
+	CurrentlyReplicatingSnapcollName *string `json:"currently_replicating_snapcoll_name,omitempty"`
 	// VolStatusList - The list of the replication status of volumes undergoing replication.
 	VolStatusList []*NsReplVolStatus `json:"vol_status_list,omitempty"`
 	// SyncReplVolStatusList - A list of the replication status of volumes undergoing synchronous replication.

--- a/pkg/client/v1/nimbleos/volume.go
+++ b/pkg/client/v1/nimbleos/volume.go
@@ -268,7 +268,7 @@ type Volume struct {
 	// PreFilter - Pre-filtering criteria.
 	PreFilter *string `json:"pre_filter,omitempty"`
 	// AvgStatsLast5mins - Average statistics in last 5 minutes.
-	AvgStatsLast5mins *NsAverageStats `json:"avg_stats_last_5mins,omitempty"`
+	AvgStatsLast5mins *NsAverageStats `json:"avg_stats_last5mins,omitempty"`
 	// SrepLastSync - Time when synchronously replicated volume was last synchronized.
 	SrepLastSync *int64 `json:"srep_last_sync,omitempty"`
 	// SrepResyncPercent - Percentage of resync progress for synchronously replicated volume.

--- a/pkg/service/group_service_factory.go
+++ b/pkg/service/group_service_factory.go
@@ -16,51 +16,54 @@ type NsGroupService struct {
 	client *client.GroupMgmtClient
 
 	// Declare all the supported services
-	versionService                    *VersionService
-	applicationCategoryService        *ApplicationCategoryService
-	chapUserService                   *ChapUserService
-	masterKeyService                  *MasterKeyService
-	alarmService                      *AlarmService
-	volumeService                     sdkprovider.VolumeService
-	shelfService                      *ShelfService
-	keyManagerService                 *KeyManagerService
-	protectionTemplateService         *ProtectionTemplateService
-	folderService                     *FolderService
-	tokenService                      *TokenService
-	fibreChannelInterfaceService      *FibreChannelInterfaceService
-	networkInterfaceService           *NetworkInterfaceService
-	arrayService                      *ArrayService
-	fibreChannelConfigService         *FibreChannelConfigService
-	initiatorService                  *InitiatorService
-	performancePolicyService          *PerformancePolicyService
-	spaceDomainService                *SpaceDomainService
-	snapshotCollectionService         *SnapshotCollectionService
-	replicationPartnerService         *ReplicationPartnerService
-	eventService                      *EventService
-	snapshotService                   *SnapshotService
-	applicationServerService          *ApplicationServerService
-	userPolicyService                 *UserPolicyService
-	userGroupService                  *UserGroupService
-	subnetService                     *SubnetService
-	controllerService                 *ControllerService
-	fibreChannelSessionService        *FibreChannelSessionService
-	userService                       *UserService
-	protectionScheduleService         *ProtectionScheduleService
-	initiatorGroupService             *InitiatorGroupService
 	accessControlRecordService        *AccessControlRecordService
 	activeDirectoryMembershipService  *ActiveDirectoryMembershipService
-	fibreChannelPortService           *FibreChannelPortService
-	protocolEndpointService           *ProtocolEndpointService
-	witnessService                    *WitnessService
-	jobService                        *JobService
+	alarmService                      *AlarmService
+	applicationCategoryService        *ApplicationCategoryService
+	applicationServerService          *ApplicationServerService
+	arrayService                      *ArrayService
 	auditLogService                   *AuditLogService
-	poolService                       sdkprovider.PoolService
-	volumeCollectionService           *VolumeCollectionService
+	chapUserService                   *ChapUserService
+	controllerService                 *ControllerService
 	diskService                       *DiskService
+	eventService                      *EventService
+	fibreChannelConfigService         *FibreChannelConfigService
 	fibreChannelInitiatorAliasService *FibreChannelInitiatorAliasService
+	fibreChannelInterfaceService      *FibreChannelInterfaceService
+	fibreChannelPortService           *FibreChannelPortService
+	fibreChannelSessionService        *FibreChannelSessionService
+	folderService                     *FolderService
 	groupService                      *GroupService
-	softwareVersionService            *SoftwareVersionService
+	initiatorGroupService             *InitiatorGroupService
+	initiatorService                  *InitiatorService
+	jobService                        *JobService
+	keyManagerService                 *KeyManagerService
+	ldapDomainService                 *LdapDomainService
+	masterKeyService                  *MasterKeyService
 	networkConfigService              *NetworkConfigService
+	networkInterfaceService           *NetworkInterfaceService
+	performancePolicyService          *PerformancePolicyService
+	poolService                       sdkprovider.PoolService
+	protectionScheduleService         *ProtectionScheduleService
+	protectionTemplateService         *ProtectionTemplateService
+	protocolEndpointService           *ProtocolEndpointService
+	replicationPartnerService         *ReplicationPartnerService
+	shelfService                      *ShelfService
+	snapshotCollectionService         *SnapshotCollectionService
+	snapshotService                   *SnapshotService
+	softwareVersionService            *SoftwareVersionService
+	spaceDomainService                *SpaceDomainService
+	subnetService                     *SubnetService
+	subscriberService                 *SubscriberService
+	subscriptionService               *SubscriptionService
+	tokenService                      *TokenService
+	userGroupService                  *UserGroupService
+	userPolicyService                 *UserPolicyService
+	userService                       *UserService
+	versionService                    *VersionService
+	volumeCollectionService           *VolumeCollectionService
+	volumeService                     sdkprovider.VolumeService
+	witnessService                    *WitnessService
 }
 
 // NewNsGroupService - initializes NsGroupService
@@ -100,254 +103,6 @@ func (gs *NsGroupService) SetDebug() {
 	gs.client.EnableDebug()
 }
 
-// GetVersionService - returns service of a type *VersionService
-func (gs *NsGroupService) GetVersionService() (vs *VersionService) {
-	if gs.versionService == nil {
-		gs.versionService = NewVersionService(gs)
-	}
-	return gs.versionService
-}
-
-// GetApplicationCategoryService - returns service of a type *ApplicationCategoryService
-func (gs *NsGroupService) GetApplicationCategoryService() (vs *ApplicationCategoryService) {
-	if gs.applicationCategoryService == nil {
-		gs.applicationCategoryService = NewApplicationCategoryService(gs)
-	}
-	return gs.applicationCategoryService
-}
-
-// GetChapUserService - returns service of a type *ChapUserService
-func (gs *NsGroupService) GetChapUserService() (vs *ChapUserService) {
-	if gs.chapUserService == nil {
-		gs.chapUserService = NewChapUserService(gs)
-	}
-	return gs.chapUserService
-}
-
-// GetMasterKeyService - returns service of a type *MasterKeyService
-func (gs *NsGroupService) GetMasterKeyService() (vs *MasterKeyService) {
-	if gs.masterKeyService == nil {
-		gs.masterKeyService = NewMasterKeyService(gs)
-	}
-	return gs.masterKeyService
-}
-
-// GetAlarmService - returns service of a type *AlarmService
-func (gs *NsGroupService) GetAlarmService() (vs *AlarmService) {
-	if gs.alarmService == nil {
-		gs.alarmService = NewAlarmService(gs)
-	}
-	return gs.alarmService
-}
-
-// GetVolumeService - returns service of a type sdkprovider.VolumeService
-func (gs *NsGroupService) GetVolumeService() (vs sdkprovider.VolumeService) {
-	if gs.volumeService == nil {
-		gs.volumeService = NewVolumeService(gs)
-	}
-	return gs.volumeService
-}
-
-// GetShelfService - returns service of a type *ShelfService
-func (gs *NsGroupService) GetShelfService() (vs *ShelfService) {
-	if gs.shelfService == nil {
-		gs.shelfService = NewShelfService(gs)
-	}
-	return gs.shelfService
-}
-
-// GetKeyManagerService - returns service of a type *KeyManagerService
-func (gs *NsGroupService) GetKeyManagerService() (vs *KeyManagerService) {
-	if gs.keyManagerService == nil {
-		gs.keyManagerService = NewKeyManagerService(gs)
-	}
-	return gs.keyManagerService
-}
-
-// GetProtectionTemplateService - returns service of a type *ProtectionTemplateService
-func (gs *NsGroupService) GetProtectionTemplateService() (vs *ProtectionTemplateService) {
-	if gs.protectionTemplateService == nil {
-		gs.protectionTemplateService = NewProtectionTemplateService(gs)
-	}
-	return gs.protectionTemplateService
-}
-
-// GetFolderService - returns service of a type *FolderService
-func (gs *NsGroupService) GetFolderService() (vs *FolderService) {
-	if gs.folderService == nil {
-		gs.folderService = NewFolderService(gs)
-	}
-	return gs.folderService
-}
-
-// GetTokenService - returns service of a type *TokenService
-func (gs *NsGroupService) GetTokenService() (vs *TokenService) {
-	if gs.tokenService == nil {
-		gs.tokenService = NewTokenService(gs)
-	}
-	return gs.tokenService
-}
-
-// GetFibreChannelInterfaceService - returns service of a type *FibreChannelInterfaceService
-func (gs *NsGroupService) GetFibreChannelInterfaceService() (vs *FibreChannelInterfaceService) {
-	if gs.fibreChannelInterfaceService == nil {
-		gs.fibreChannelInterfaceService = NewFibreChannelInterfaceService(gs)
-	}
-	return gs.fibreChannelInterfaceService
-}
-
-// GetNetworkInterfaceService - returns service of a type *NetworkInterfaceService
-func (gs *NsGroupService) GetNetworkInterfaceService() (vs *NetworkInterfaceService) {
-	if gs.networkInterfaceService == nil {
-		gs.networkInterfaceService = NewNetworkInterfaceService(gs)
-	}
-	return gs.networkInterfaceService
-}
-
-// GetArrayService - returns service of a type *ArrayService
-func (gs *NsGroupService) GetArrayService() (vs *ArrayService) {
-	if gs.arrayService == nil {
-		gs.arrayService = NewArrayService(gs)
-	}
-	return gs.arrayService
-}
-
-// GetFibreChannelConfigService - returns service of a type *FibreChannelConfigService
-func (gs *NsGroupService) GetFibreChannelConfigService() (vs *FibreChannelConfigService) {
-	if gs.fibreChannelConfigService == nil {
-		gs.fibreChannelConfigService = NewFibreChannelConfigService(gs)
-	}
-	return gs.fibreChannelConfigService
-}
-
-// GetInitiatorService - returns service of a type *InitiatorService
-func (gs *NsGroupService) GetInitiatorService() (vs *InitiatorService) {
-	if gs.initiatorService == nil {
-		gs.initiatorService = NewInitiatorService(gs)
-	}
-	return gs.initiatorService
-}
-
-// GetPerformancePolicyService - returns service of a type *PerformancePolicyService
-func (gs *NsGroupService) GetPerformancePolicyService() (vs *PerformancePolicyService) {
-	if gs.performancePolicyService == nil {
-		gs.performancePolicyService = NewPerformancePolicyService(gs)
-	}
-	return gs.performancePolicyService
-}
-
-// GetSpaceDomainService - returns service of a type *SpaceDomainService
-func (gs *NsGroupService) GetSpaceDomainService() (vs *SpaceDomainService) {
-	if gs.spaceDomainService == nil {
-		gs.spaceDomainService = NewSpaceDomainService(gs)
-	}
-	return gs.spaceDomainService
-}
-
-// GetSnapshotCollectionService - returns service of a type *SnapshotCollectionService
-func (gs *NsGroupService) GetSnapshotCollectionService() (vs *SnapshotCollectionService) {
-	if gs.snapshotCollectionService == nil {
-		gs.snapshotCollectionService = NewSnapshotCollectionService(gs)
-	}
-	return gs.snapshotCollectionService
-}
-
-// GetReplicationPartnerService - returns service of a type *ReplicationPartnerService
-func (gs *NsGroupService) GetReplicationPartnerService() (vs *ReplicationPartnerService) {
-	if gs.replicationPartnerService == nil {
-		gs.replicationPartnerService = NewReplicationPartnerService(gs)
-	}
-	return gs.replicationPartnerService
-}
-
-// GetEventService - returns service of a type *EventService
-func (gs *NsGroupService) GetEventService() (vs *EventService) {
-	if gs.eventService == nil {
-		gs.eventService = NewEventService(gs)
-	}
-	return gs.eventService
-}
-
-// GetSnapshotService - returns service of a type *SnapshotService
-func (gs *NsGroupService) GetSnapshotService() (vs *SnapshotService) {
-	if gs.snapshotService == nil {
-		gs.snapshotService = NewSnapshotService(gs)
-	}
-	return gs.snapshotService
-}
-
-// GetApplicationServerService - returns service of a type *ApplicationServerService
-func (gs *NsGroupService) GetApplicationServerService() (vs *ApplicationServerService) {
-	if gs.applicationServerService == nil {
-		gs.applicationServerService = NewApplicationServerService(gs)
-	}
-	return gs.applicationServerService
-}
-
-// GetUserPolicyService - returns service of a type *UserPolicyService
-func (gs *NsGroupService) GetUserPolicyService() (vs *UserPolicyService) {
-	if gs.userPolicyService == nil {
-		gs.userPolicyService = NewUserPolicyService(gs)
-	}
-	return gs.userPolicyService
-}
-
-// GetUserGroupService - returns service of a type *UserGroupService
-func (gs *NsGroupService) GetUserGroupService() (vs *UserGroupService) {
-	if gs.userGroupService == nil {
-		gs.userGroupService = NewUserGroupService(gs)
-	}
-	return gs.userGroupService
-}
-
-// GetSubnetService - returns service of a type *SubnetService
-func (gs *NsGroupService) GetSubnetService() (vs *SubnetService) {
-	if gs.subnetService == nil {
-		gs.subnetService = NewSubnetService(gs)
-	}
-	return gs.subnetService
-}
-
-// GetControllerService - returns service of a type *ControllerService
-func (gs *NsGroupService) GetControllerService() (vs *ControllerService) {
-	if gs.controllerService == nil {
-		gs.controllerService = NewControllerService(gs)
-	}
-	return gs.controllerService
-}
-
-// GetFibreChannelSessionService - returns service of a type *FibreChannelSessionService
-func (gs *NsGroupService) GetFibreChannelSessionService() (vs *FibreChannelSessionService) {
-	if gs.fibreChannelSessionService == nil {
-		gs.fibreChannelSessionService = NewFibreChannelSessionService(gs)
-	}
-	return gs.fibreChannelSessionService
-}
-
-// GetUserService - returns service of a type *UserService
-func (gs *NsGroupService) GetUserService() (vs *UserService) {
-	if gs.userService == nil {
-		gs.userService = NewUserService(gs)
-	}
-	return gs.userService
-}
-
-// GetProtectionScheduleService - returns service of a type *ProtectionScheduleService
-func (gs *NsGroupService) GetProtectionScheduleService() (vs *ProtectionScheduleService) {
-	if gs.protectionScheduleService == nil {
-		gs.protectionScheduleService = NewProtectionScheduleService(gs)
-	}
-	return gs.protectionScheduleService
-}
-
-// GetInitiatorGroupService - returns service of a type *InitiatorGroupService
-func (gs *NsGroupService) GetInitiatorGroupService() (vs *InitiatorGroupService) {
-	if gs.initiatorGroupService == nil {
-		gs.initiatorGroupService = NewInitiatorGroupService(gs)
-	}
-	return gs.initiatorGroupService
-}
-
 // GetAccessControlRecordService - returns service of a type *AccessControlRecordService
 func (gs *NsGroupService) GetAccessControlRecordService() (vs *AccessControlRecordService) {
 	if gs.accessControlRecordService == nil {
@@ -364,36 +119,36 @@ func (gs *NsGroupService) GetActiveDirectoryMembershipService() (vs *ActiveDirec
 	return gs.activeDirectoryMembershipService
 }
 
-// GetFibreChannelPortService - returns service of a type *FibreChannelPortService
-func (gs *NsGroupService) GetFibreChannelPortService() (vs *FibreChannelPortService) {
-	if gs.fibreChannelPortService == nil {
-		gs.fibreChannelPortService = NewFibreChannelPortService(gs)
+// GetAlarmService - returns service of a type *AlarmService
+func (gs *NsGroupService) GetAlarmService() (vs *AlarmService) {
+	if gs.alarmService == nil {
+		gs.alarmService = NewAlarmService(gs)
 	}
-	return gs.fibreChannelPortService
+	return gs.alarmService
 }
 
-// GetProtocolEndpointService - returns service of a type *ProtocolEndpointService
-func (gs *NsGroupService) GetProtocolEndpointService() (vs *ProtocolEndpointService) {
-	if gs.protocolEndpointService == nil {
-		gs.protocolEndpointService = NewProtocolEndpointService(gs)
+// GetApplicationCategoryService - returns service of a type *ApplicationCategoryService
+func (gs *NsGroupService) GetApplicationCategoryService() (vs *ApplicationCategoryService) {
+	if gs.applicationCategoryService == nil {
+		gs.applicationCategoryService = NewApplicationCategoryService(gs)
 	}
-	return gs.protocolEndpointService
+	return gs.applicationCategoryService
 }
 
-// GetWitnessService - returns service of a type *WitnessService
-func (gs *NsGroupService) GetWitnessService() (vs *WitnessService) {
-	if gs.witnessService == nil {
-		gs.witnessService = NewWitnessService(gs)
+// GetApplicationServerService - returns service of a type *ApplicationServerService
+func (gs *NsGroupService) GetApplicationServerService() (vs *ApplicationServerService) {
+	if gs.applicationServerService == nil {
+		gs.applicationServerService = NewApplicationServerService(gs)
 	}
-	return gs.witnessService
+	return gs.applicationServerService
 }
 
-// GetJobService - returns service of a type *JobService
-func (gs *NsGroupService) GetJobService() (vs *JobService) {
-	if gs.jobService == nil {
-		gs.jobService = NewJobService(gs)
+// GetArrayService - returns service of a type *ArrayService
+func (gs *NsGroupService) GetArrayService() (vs *ArrayService) {
+	if gs.arrayService == nil {
+		gs.arrayService = NewArrayService(gs)
 	}
-	return gs.jobService
+	return gs.arrayService
 }
 
 // GetAuditLogService - returns service of a type *AuditLogService
@@ -404,20 +159,20 @@ func (gs *NsGroupService) GetAuditLogService() (vs *AuditLogService) {
 	return gs.auditLogService
 }
 
-// GetPoolService - returns service of a type sdkprovider.PoolService
-func (gs *NsGroupService) GetPoolService() (vs sdkprovider.PoolService) {
-	if gs.poolService == nil {
-		gs.poolService = NewPoolService(gs)
+// GetChapUserService - returns service of a type *ChapUserService
+func (gs *NsGroupService) GetChapUserService() (vs *ChapUserService) {
+	if gs.chapUserService == nil {
+		gs.chapUserService = NewChapUserService(gs)
 	}
-	return gs.poolService
+	return gs.chapUserService
 }
 
-// GetVolumeCollectionService - returns service of a type *VolumeCollectionService
-func (gs *NsGroupService) GetVolumeCollectionService() (vs *VolumeCollectionService) {
-	if gs.volumeCollectionService == nil {
-		gs.volumeCollectionService = NewVolumeCollectionService(gs)
+// GetControllerService - returns service of a type *ControllerService
+func (gs *NsGroupService) GetControllerService() (vs *ControllerService) {
+	if gs.controllerService == nil {
+		gs.controllerService = NewControllerService(gs)
 	}
-	return gs.volumeCollectionService
+	return gs.controllerService
 }
 
 // GetDiskService - returns service of a type *DiskService
@@ -428,12 +183,60 @@ func (gs *NsGroupService) GetDiskService() (vs *DiskService) {
 	return gs.diskService
 }
 
+// GetEventService - returns service of a type *EventService
+func (gs *NsGroupService) GetEventService() (vs *EventService) {
+	if gs.eventService == nil {
+		gs.eventService = NewEventService(gs)
+	}
+	return gs.eventService
+}
+
+// GetFibreChannelConfigService - returns service of a type *FibreChannelConfigService
+func (gs *NsGroupService) GetFibreChannelConfigService() (vs *FibreChannelConfigService) {
+	if gs.fibreChannelConfigService == nil {
+		gs.fibreChannelConfigService = NewFibreChannelConfigService(gs)
+	}
+	return gs.fibreChannelConfigService
+}
+
 // GetFibreChannelInitiatorAliasService - returns service of a type *FibreChannelInitiatorAliasService
 func (gs *NsGroupService) GetFibreChannelInitiatorAliasService() (vs *FibreChannelInitiatorAliasService) {
 	if gs.fibreChannelInitiatorAliasService == nil {
 		gs.fibreChannelInitiatorAliasService = NewFibreChannelInitiatorAliasService(gs)
 	}
 	return gs.fibreChannelInitiatorAliasService
+}
+
+// GetFibreChannelInterfaceService - returns service of a type *FibreChannelInterfaceService
+func (gs *NsGroupService) GetFibreChannelInterfaceService() (vs *FibreChannelInterfaceService) {
+	if gs.fibreChannelInterfaceService == nil {
+		gs.fibreChannelInterfaceService = NewFibreChannelInterfaceService(gs)
+	}
+	return gs.fibreChannelInterfaceService
+}
+
+// GetFibreChannelPortService - returns service of a type *FibreChannelPortService
+func (gs *NsGroupService) GetFibreChannelPortService() (vs *FibreChannelPortService) {
+	if gs.fibreChannelPortService == nil {
+		gs.fibreChannelPortService = NewFibreChannelPortService(gs)
+	}
+	return gs.fibreChannelPortService
+}
+
+// GetFibreChannelSessionService - returns service of a type *FibreChannelSessionService
+func (gs *NsGroupService) GetFibreChannelSessionService() (vs *FibreChannelSessionService) {
+	if gs.fibreChannelSessionService == nil {
+		gs.fibreChannelSessionService = NewFibreChannelSessionService(gs)
+	}
+	return gs.fibreChannelSessionService
+}
+
+// GetFolderService - returns service of a type *FolderService
+func (gs *NsGroupService) GetFolderService() (vs *FolderService) {
+	if gs.folderService == nil {
+		gs.folderService = NewFolderService(gs)
+	}
+	return gs.folderService
 }
 
 // GetGroupService - returns service of a type *GroupService
@@ -444,12 +247,52 @@ func (gs *NsGroupService) GetGroupService() (vs *GroupService) {
 	return gs.groupService
 }
 
-// GetSoftwareVersionService - returns service of a type *SoftwareVersionService
-func (gs *NsGroupService) GetSoftwareVersionService() (vs *SoftwareVersionService) {
-	if gs.softwareVersionService == nil {
-		gs.softwareVersionService = NewSoftwareVersionService(gs)
+// GetInitiatorGroupService - returns service of a type *InitiatorGroupService
+func (gs *NsGroupService) GetInitiatorGroupService() (vs *InitiatorGroupService) {
+	if gs.initiatorGroupService == nil {
+		gs.initiatorGroupService = NewInitiatorGroupService(gs)
 	}
-	return gs.softwareVersionService
+	return gs.initiatorGroupService
+}
+
+// GetInitiatorService - returns service of a type *InitiatorService
+func (gs *NsGroupService) GetInitiatorService() (vs *InitiatorService) {
+	if gs.initiatorService == nil {
+		gs.initiatorService = NewInitiatorService(gs)
+	}
+	return gs.initiatorService
+}
+
+// GetJobService - returns service of a type *JobService
+func (gs *NsGroupService) GetJobService() (vs *JobService) {
+	if gs.jobService == nil {
+		gs.jobService = NewJobService(gs)
+	}
+	return gs.jobService
+}
+
+// GetKeyManagerService - returns service of a type *KeyManagerService
+func (gs *NsGroupService) GetKeyManagerService() (vs *KeyManagerService) {
+	if gs.keyManagerService == nil {
+		gs.keyManagerService = NewKeyManagerService(gs)
+	}
+	return gs.keyManagerService
+}
+
+// GetLdapDomainService - returns service of a type *LdapDomainService
+func (gs *NsGroupService) GetLdapDomainService() (vs *LdapDomainService) {
+	if gs.ldapDomainService == nil {
+		gs.ldapDomainService = NewLdapDomainService(gs)
+	}
+	return gs.ldapDomainService
+}
+
+// GetMasterKeyService - returns service of a type *MasterKeyService
+func (gs *NsGroupService) GetMasterKeyService() (vs *MasterKeyService) {
+	if gs.masterKeyService == nil {
+		gs.masterKeyService = NewMasterKeyService(gs)
+	}
+	return gs.masterKeyService
 }
 
 // GetNetworkConfigService - returns service of a type *NetworkConfigService
@@ -458,4 +301,188 @@ func (gs *NsGroupService) GetNetworkConfigService() (vs *NetworkConfigService) {
 		gs.networkConfigService = NewNetworkConfigService(gs)
 	}
 	return gs.networkConfigService
+}
+
+// GetNetworkInterfaceService - returns service of a type *NetworkInterfaceService
+func (gs *NsGroupService) GetNetworkInterfaceService() (vs *NetworkInterfaceService) {
+	if gs.networkInterfaceService == nil {
+		gs.networkInterfaceService = NewNetworkInterfaceService(gs)
+	}
+	return gs.networkInterfaceService
+}
+
+// GetPerformancePolicyService - returns service of a type *PerformancePolicyService
+func (gs *NsGroupService) GetPerformancePolicyService() (vs *PerformancePolicyService) {
+	if gs.performancePolicyService == nil {
+		gs.performancePolicyService = NewPerformancePolicyService(gs)
+	}
+	return gs.performancePolicyService
+}
+
+// GetPoolService - returns service of a type sdkprovider.PoolService
+func (gs *NsGroupService) GetPoolService() (vs sdkprovider.PoolService) {
+	if gs.poolService == nil {
+		gs.poolService = NewPoolService(gs)
+	}
+	return gs.poolService
+}
+
+// GetProtectionScheduleService - returns service of a type *ProtectionScheduleService
+func (gs *NsGroupService) GetProtectionScheduleService() (vs *ProtectionScheduleService) {
+	if gs.protectionScheduleService == nil {
+		gs.protectionScheduleService = NewProtectionScheduleService(gs)
+	}
+	return gs.protectionScheduleService
+}
+
+// GetProtectionTemplateService - returns service of a type *ProtectionTemplateService
+func (gs *NsGroupService) GetProtectionTemplateService() (vs *ProtectionTemplateService) {
+	if gs.protectionTemplateService == nil {
+		gs.protectionTemplateService = NewProtectionTemplateService(gs)
+	}
+	return gs.protectionTemplateService
+}
+
+// GetProtocolEndpointService - returns service of a type *ProtocolEndpointService
+func (gs *NsGroupService) GetProtocolEndpointService() (vs *ProtocolEndpointService) {
+	if gs.protocolEndpointService == nil {
+		gs.protocolEndpointService = NewProtocolEndpointService(gs)
+	}
+	return gs.protocolEndpointService
+}
+
+// GetReplicationPartnerService - returns service of a type *ReplicationPartnerService
+func (gs *NsGroupService) GetReplicationPartnerService() (vs *ReplicationPartnerService) {
+	if gs.replicationPartnerService == nil {
+		gs.replicationPartnerService = NewReplicationPartnerService(gs)
+	}
+	return gs.replicationPartnerService
+}
+
+// GetShelfService - returns service of a type *ShelfService
+func (gs *NsGroupService) GetShelfService() (vs *ShelfService) {
+	if gs.shelfService == nil {
+		gs.shelfService = NewShelfService(gs)
+	}
+	return gs.shelfService
+}
+
+// GetSnapshotCollectionService - returns service of a type *SnapshotCollectionService
+func (gs *NsGroupService) GetSnapshotCollectionService() (vs *SnapshotCollectionService) {
+	if gs.snapshotCollectionService == nil {
+		gs.snapshotCollectionService = NewSnapshotCollectionService(gs)
+	}
+	return gs.snapshotCollectionService
+}
+
+// GetSnapshotService - returns service of a type *SnapshotService
+func (gs *NsGroupService) GetSnapshotService() (vs *SnapshotService) {
+	if gs.snapshotService == nil {
+		gs.snapshotService = NewSnapshotService(gs)
+	}
+	return gs.snapshotService
+}
+
+// GetSoftwareVersionService - returns service of a type *SoftwareVersionService
+func (gs *NsGroupService) GetSoftwareVersionService() (vs *SoftwareVersionService) {
+	if gs.softwareVersionService == nil {
+		gs.softwareVersionService = NewSoftwareVersionService(gs)
+	}
+	return gs.softwareVersionService
+}
+
+// GetSpaceDomainService - returns service of a type *SpaceDomainService
+func (gs *NsGroupService) GetSpaceDomainService() (vs *SpaceDomainService) {
+	if gs.spaceDomainService == nil {
+		gs.spaceDomainService = NewSpaceDomainService(gs)
+	}
+	return gs.spaceDomainService
+}
+
+// GetSubnetService - returns service of a type *SubnetService
+func (gs *NsGroupService) GetSubnetService() (vs *SubnetService) {
+	if gs.subnetService == nil {
+		gs.subnetService = NewSubnetService(gs)
+	}
+	return gs.subnetService
+}
+
+// GetSubscriberService - returns service of a type *SubscriberService
+func (gs *NsGroupService) GetSubscriberService() (vs *SubscriberService) {
+	if gs.subscriberService == nil {
+		gs.subscriberService = NewSubscriberService(gs)
+	}
+	return gs.subscriberService
+}
+
+// GetSubscriptionService - returns service of a type *SubscriptionService
+func (gs *NsGroupService) GetSubscriptionService() (vs *SubscriptionService) {
+	if gs.subscriptionService == nil {
+		gs.subscriptionService = NewSubscriptionService(gs)
+	}
+	return gs.subscriptionService
+}
+
+// GetTokenService - returns service of a type *TokenService
+func (gs *NsGroupService) GetTokenService() (vs *TokenService) {
+	if gs.tokenService == nil {
+		gs.tokenService = NewTokenService(gs)
+	}
+	return gs.tokenService
+}
+
+// GetUserGroupService - returns service of a type *UserGroupService
+func (gs *NsGroupService) GetUserGroupService() (vs *UserGroupService) {
+	if gs.userGroupService == nil {
+		gs.userGroupService = NewUserGroupService(gs)
+	}
+	return gs.userGroupService
+}
+
+// GetUserPolicyService - returns service of a type *UserPolicyService
+func (gs *NsGroupService) GetUserPolicyService() (vs *UserPolicyService) {
+	if gs.userPolicyService == nil {
+		gs.userPolicyService = NewUserPolicyService(gs)
+	}
+	return gs.userPolicyService
+}
+
+// GetUserService - returns service of a type *UserService
+func (gs *NsGroupService) GetUserService() (vs *UserService) {
+	if gs.userService == nil {
+		gs.userService = NewUserService(gs)
+	}
+	return gs.userService
+}
+
+// GetVersionService - returns service of a type *VersionService
+func (gs *NsGroupService) GetVersionService() (vs *VersionService) {
+	if gs.versionService == nil {
+		gs.versionService = NewVersionService(gs)
+	}
+	return gs.versionService
+}
+
+// GetVolumeCollectionService - returns service of a type *VolumeCollectionService
+func (gs *NsGroupService) GetVolumeCollectionService() (vs *VolumeCollectionService) {
+	if gs.volumeCollectionService == nil {
+		gs.volumeCollectionService = NewVolumeCollectionService(gs)
+	}
+	return gs.volumeCollectionService
+}
+
+// GetVolumeService - returns service of a type sdkprovider.VolumeService
+func (gs *NsGroupService) GetVolumeService() (vs sdkprovider.VolumeService) {
+	if gs.volumeService == nil {
+		gs.volumeService = NewVolumeService(gs)
+	}
+	return gs.volumeService
+}
+
+// GetWitnessService - returns service of a type *WitnessService
+func (gs *NsGroupService) GetWitnessService() (vs *WitnessService) {
+	if gs.witnessService == nil {
+		gs.witnessService = NewWitnessService(gs)
+	}
+	return gs.witnessService
 }

--- a/pkg/service/ldap_domain_service.go
+++ b/pkg/service/ldap_domain_service.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// LdapDomain Service - Manages the storage array's membership with LDAP servers.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// LdapDomainService type
+type LdapDomainService struct {
+	objectSet *client.LdapDomainObjectSet
+}
+
+// NewLdapDomainService - method to initialize "LdapDomainService"
+func NewLdapDomainService(gs *NsGroupService) *LdapDomainService {
+	objectSet := gs.client.GetLdapDomainObjectSet()
+	return &LdapDomainService{objectSet: objectSet}
+}
+
+// GetLdapDomains - method returns a array of pointers of type "LdapDomains"
+func (svc *LdapDomainService) GetLdapDomains(params *param.GetParams) ([]*nimbleos.LdapDomain, error) {
+	ldapDomainResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// CreateLdapDomain - method creates a "LdapDomain"
+func (svc *LdapDomainService) CreateLdapDomain(obj *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateLdapDomain: invalid parameter specified, %v", obj)
+	}
+
+	ldapDomainResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// UpdateLdapDomain - method modifies  the "LdapDomain"
+func (svc *LdapDomainService) UpdateLdapDomain(id string, obj *nimbleos.LdapDomain) (*nimbleos.LdapDomain, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateLdapDomain: invalid parameter specified, %v", obj)
+	}
+
+	ldapDomainResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// GetLdapDomainById - method returns a pointer to "LdapDomain"
+func (svc *LdapDomainService) GetLdapDomainById(id string) (*nimbleos.LdapDomain, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetLdapDomainById: invalid parameter specified, %v", id)
+	}
+
+	ldapDomainResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return ldapDomainResp, nil
+}
+
+// DeleteLdapDomain - deletes the "LdapDomain"
+func (svc *LdapDomainService) DeleteLdapDomain(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteLdapDomain: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TestUserLdapDomain - tests whether the user exist in the given LDAP Domain.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+//       user - Name of the LDAP Domain user.
+
+func (svc *LdapDomainService) TestUserLdapDomain(id string, user string) (*nimbleos.NsLdapUser, error) {
+
+	if len(id) == 0 || len(user) == 0 {
+		return nil, fmt.Errorf("TestUserLdapDomain: invalid parameter specified id: %v, user: %v ", id, user)
+	}
+
+	resp, err := svc.objectSet.TestUser(&id, &user)
+	return resp, err
+}
+
+// TestGroupLdapDomain - tests whether the user group exist in the given LDAP Domain.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+//       group - Name of the group.
+
+func (svc *LdapDomainService) TestGroupLdapDomain(id string, group string) error {
+
+	if len(id) == 0 || len(group) == 0 {
+		return fmt.Errorf("TestGroupLdapDomain: invalid parameter specified id: %v, group: %v ", id, group)
+	}
+
+	err := svc.objectSet.TestGroup(&id, &group)
+	return err
+}
+
+// ReportStatusLdapDomain - reports the LDAP connectivity status of the given LDAP ID.
+//   Required parameters:
+//       id - Unique identifier for the LDAP Domain.
+
+func (svc *LdapDomainService) ReportStatusLdapDomain(id string) (*nimbleos.NsLdapReportStatusReturn, error) {
+
+	if len(id) == 0 {
+		return nil, fmt.Errorf("ReportStatusLdapDomain: invalid parameter specified id: %v ", id)
+	}
+
+	resp, err := svc.objectSet.ReportStatus(&id)
+	return resp, err
+}

--- a/pkg/service/subscriber_service.go
+++ b/pkg/service/subscriber_service.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// Subscriber Service - Subscribers are websocket based notification clients that can subscribe to interesting operations and events and recieve notifications whenever the subscribed to operations and
+// events happen on the array.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// SubscriberService type
+type SubscriberService struct {
+	objectSet *client.SubscriberObjectSet
+}
+
+// NewSubscriberService - method to initialize "SubscriberService"
+func NewSubscriberService(gs *NsGroupService) *SubscriberService {
+	objectSet := gs.client.GetSubscriberObjectSet()
+	return &SubscriberService{objectSet: objectSet}
+}
+
+// GetSubscribers - method returns a array of pointers of type "Subscribers"
+func (svc *SubscriberService) GetSubscribers(params *param.GetParams) ([]*nimbleos.Subscriber, error) {
+	subscriberResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// CreateSubscriber - method creates a "Subscriber"
+func (svc *SubscriberService) CreateSubscriber(obj *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateSubscriber: invalid parameter specified, %v", obj)
+	}
+
+	subscriberResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// UpdateSubscriber - method modifies  the "Subscriber"
+func (svc *SubscriberService) UpdateSubscriber(id string, obj *nimbleos.Subscriber) (*nimbleos.Subscriber, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateSubscriber: invalid parameter specified, %v", obj)
+	}
+
+	subscriberResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// GetSubscriberById - method returns a pointer to "Subscriber"
+func (svc *SubscriberService) GetSubscriberById(id string) (*nimbleos.Subscriber, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetSubscriberById: invalid parameter specified, %v", id)
+	}
+
+	subscriberResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return subscriberResp, nil
+}
+
+// DeleteSubscriber - deletes the "Subscriber"
+func (svc *SubscriberService) DeleteSubscriber(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteSubscriber: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/service/subscription_service.go
+++ b/pkg/service/subscription_service.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Hewlett Packard Enterprise Development LP
+
+package service
+
+// Subscription Service - Subscriptions represent the list of object types or alerts that a websocket client is interested in getting notifications for. Each subscription belongs to a single notification
+// client.
+
+import (
+	"fmt"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
+	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
+)
+
+// SubscriptionService type
+type SubscriptionService struct {
+	objectSet *client.SubscriptionObjectSet
+}
+
+// NewSubscriptionService - method to initialize "SubscriptionService"
+func NewSubscriptionService(gs *NsGroupService) *SubscriptionService {
+	objectSet := gs.client.GetSubscriptionObjectSet()
+	return &SubscriptionService{objectSet: objectSet}
+}
+
+// GetSubscriptions - method returns a array of pointers of type "Subscriptions"
+func (svc *SubscriptionService) GetSubscriptions(params *param.GetParams) ([]*nimbleos.Subscription, error) {
+	subscriptionResp, err := svc.objectSet.GetObjectListFromParams(params)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// CreateSubscription - method creates a "Subscription"
+func (svc *SubscriptionService) CreateSubscription(obj *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("CreateSubscription: invalid parameter specified, %v", obj)
+	}
+
+	subscriptionResp, err := svc.objectSet.CreateObject(obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// UpdateSubscription - method modifies  the "Subscription"
+func (svc *SubscriptionService) UpdateSubscription(id string, obj *nimbleos.Subscription) (*nimbleos.Subscription, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("UpdateSubscription: invalid parameter specified, %v", obj)
+	}
+
+	subscriptionResp, err := svc.objectSet.UpdateObject(id, obj)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// GetSubscriptionById - method returns a pointer to "Subscription"
+func (svc *SubscriptionService) GetSubscriptionById(id string) (*nimbleos.Subscription, error) {
+	if len(id) == 0 {
+		return nil, fmt.Errorf("GetSubscriptionById: invalid parameter specified, %v", id)
+	}
+
+	subscriptionResp, err := svc.objectSet.GetObject(id)
+	if err != nil {
+		return nil, err
+	}
+	return subscriptionResp, nil
+}
+
+// DeleteSubscription - deletes the "Subscription"
+func (svc *SubscriptionService) DeleteSubscription(id string) error {
+	if len(id) == 0 {
+		return fmt.Errorf("DeleteSubscription: invalid parameter specified, %s", id)
+	}
+	err := svc.objectSet.DeleteObject(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
SDK stubs are auto-generated for NimOS 5.3 . 

vsingh:service vidhut.singh$ go test -v
=== RUN   TestVolumeServiceTestSuite
=== RUN   TestVolumeServiceTestSuite/TestACLVolume
=== RUN   TestVolumeServiceTestSuite/TestAddVolumeVolcoll
=== RUN   TestVolumeServiceTestSuite/TestCloneVolume
=== RUN   TestVolumeServiceTestSuite/TestExpiredToken
=== RUN   TestVolumeServiceTestSuite/TestGetNonExistentVolumeByID
=== RUN   TestVolumeServiceTestSuite/TestGetVolumes
=== RUN   TestVolumeServiceTestSuite/TestGetVolumesPagination
=== RUN   TestVolumeServiceTestSuite/TestOnlineBulkVolumes
=== RUN   TestVolumeServiceTestSuite/TestRestoreVolume
=== RUN   TestVolumeServiceTestSuite/TestVolumeFields
=== RUN   TestVolumeServiceTestSuite/TestVolumeMultiSearchFilters
=== RUN   TestVolumeServiceTestSuite/TestVolumeSearchFilters
=== RUN   TestVolumeServiceTestSuite/TestVolumeSortFilters
--- PASS: TestVolumeServiceTestSuite (169.94s)
    --- PASS: TestVolumeServiceTestSuite/TestACLVolume (14.23s)
    --- PASS: TestVolumeServiceTestSuite/TestAddVolumeVolcoll (13.99s)
    --- PASS: TestVolumeServiceTestSuite/TestCloneVolume (17.46s)
    --- PASS: TestVolumeServiceTestSuite/TestExpiredToken (13.97s)
    --- PASS: TestVolumeServiceTestSuite/TestGetNonExistentVolumeByID (11.16s)
    --- PASS: TestVolumeServiceTestSuite/TestGetVolumes (10.38s)
    --- PASS: TestVolumeServiceTestSuite/TestGetVolumesPagination (14.39s)
    --- PASS: TestVolumeServiceTestSuite/TestOnlineBulkVolumes (12.00s)
    --- PASS: TestVolumeServiceTestSuite/TestRestoreVolume (18.06s)
    --- PASS: TestVolumeServiceTestSuite/TestVolumeFields (11.21s)
    --- PASS: TestVolumeServiceTestSuite/TestVolumeMultiSearchFilters (10.55s)
    --- PASS: TestVolumeServiceTestSuite/TestVolumeSearchFilters (11.09s)
    --- PASS: TestVolumeServiceTestSuite/TestVolumeSortFilters (11.45s)
PASS
ok  	github.com/hpe-storage/nimble-golang-sdk/pkg/service	171.356s
Signed-off-by: vidhutsingh <vidhut-kumar.singh@hpe.com>