### PR TITLE
SA-207, Go SDK gets stuck in indefinite login retry if array password is changed . Applicable only for long running job. 

### DIFF
--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -61,21 +61,28 @@ type Argument struct {
 	JobId string `json:"job_id,omitempty"`
 }
 
-// NewClient instantiates a new client to communicate with the Nimble group
-func NewClient(ipAddress, username, password, apiVersion string, waitOnJobs bool) (*GroupMgmtClient, error) {
-	// Create GroupMgmt Client
-	client := resty.New()
-	client.SetTLSClientConfig(&tls.Config{
+func newGroupMgmtClient(ipAddress, username, password, apiVersion string, waitOnJobs bool) *GroupMgmtClient {
+	// Get new resty()
+	restyClient := resty.New()
+	restyClient.SetTLSClientConfig(&tls.Config{
 		InsecureSkipVerify: true,
 	})
+
+	// Create GroupMgmt Client
 	groupMgmtClient := &GroupMgmtClient{
 		URL:       fmt.Sprintf("https://%s:5392/%s", ipAddress, apiVersion),
-		Client:    client,
+		Client:    restyClient,
 		WaitOnJob: waitOnJobs,
 		Username:  username,
 		Password:  password,
 	}
+	return groupMgmtClient
+}
 
+// NewClient instantiates a new client to communicate with the Nimble group
+func NewClient(ipAddress, username, password, apiVersion string, waitOnJobs bool) (*GroupMgmtClient, error) {
+	// Get resty client
+	groupMgmtClient := newGroupMgmtClient(ipAddress, username, password, apiVersion, waitOnJobs)
 	// Get session token
 	sessionToken, err := groupMgmtClient.login(username, password)
 	if err != nil {
@@ -83,24 +90,34 @@ func NewClient(ipAddress, username, password, apiVersion string, waitOnJobs bool
 	}
 	groupMgmtClient.SessionToken = sessionToken
 
+	// Login retry counter
+	loginRetry := 0
 	// Add retryCondition
 	groupMgmtClient.Client.
-		SetRetryCount(maxOpsRetries).
 		AddRetryCondition(
 			func(resp *resty.Response, err error) bool {
+
 				if err == nil && resp.StatusCode() == 401 {
 					// login again and refreh the session token
-					sessionToken, err = groupMgmtClient.login(username, password)
-					if err != nil {
+					loginRetry++
+					if loginRetry == maxLoginRetries {
+						// exhausted the login attempt. backoff now .
 						return false
 					}
+					newGroupMgmtClient := newGroupMgmtClient(ipAddress, username, password, apiVersion, waitOnJobs)
+					sessionToken, err = newGroupMgmtClient.login(username, password)
+					if err != nil {
+						// returning true would retry the login again with new instance of group mgmt client
+						return true
+					}
+					// replace the original client session token with new session token
 					groupMgmtClient.SessionToken = sessionToken
 					resp.Request.SetHeader("X-Auth-Token", groupMgmtClient.SessionToken)
-					return true
+					return false
 				}
 				return false
 			},
-		)
+		).SetRetryCount(1)
 	return groupMgmtClient, nil
 }
 

--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -21,7 +21,6 @@ const (
 	jobTimeout      = time.Second * 300 // 5 Minute
 	jobPollInterval = 5 * time.Second   // Second
 	smAsyncJobId    = "SM_async_job_id"
-	maxOpsRetries   = 2
 )
 
 // GroupMgmtClient :


### PR DESCRIPTION
The issue will occur under following conditions:
Long running application.
User login to the Nimble Array and change the password while application is still running.
 
Although, it is a very corner case but still serious bug with SDK since it get stuck in indefinite retry login attempt and never returns to app . Thanks for file the defect.
 
Quick workaround would be to  restart the application however this may not be acceptable solution.
 
RCA :
group_mgmt_client.go :
 
AddRetryCondition() is not working properly as it is recursively calling
sessionToken, err := groupMgmtClient.login(username, password) since the password has changed on Array and the SDK still uses the old username , password so it never returns to app.  
 
Code fix:
I have added a new variable “loginRetry” in AddRetryCondition() which keep track of no of login attempt , if it exhaust the default 5
It returns to caller. Also inside the AddRetryCondition() , we should create a new instance of groupMgmtClient and replace the new session_token with old session token with original groupMgmtClient.
 
The code fix changes has worked and I will send the code for review today by eod.
 
Signed-off-by: vidhut-kumar-singh <vidhut-kumar.singh@hpe.com>