### PR TITLE
Add option to provide a custom tls.Config to allow control over the tls connection

### DIFF
--- a/pkg/client/group_mgmt_client.go
+++ b/pkg/client/group_mgmt_client.go
@@ -62,12 +62,16 @@ type Argument struct {
 	JobId string `json:"job_id,omitempty"`
 }
 
-func newGroupMgmtClient(ipAddress, username, password, apiVersion string, waitOnJobs, isTenant bool) *GroupMgmtClient {
+func newGroupMgmtClient(ipAddress, username, password, apiVersion string, waitOnJobs, isTenant bool, tlsConfig *tls.Config) *GroupMgmtClient {
+	if tlsConfig == nil && !isTenant {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
 	// Get new resty()
 	restyClient := resty.New()
-	restyClient.SetTLSClientConfig(&tls.Config{
-		InsecureSkipVerify: true,
-	})
+	restyClient.SetTLSClientConfig(tlsConfig)
 
 	// Create GroupMgmt Client
 	groupMgmtClient := &GroupMgmtClient{
@@ -88,13 +92,13 @@ func newGroupMgmtClient(ipAddress, username, password, apiVersion string, waitOn
 }
 
 // NewClient instantiates a new client to communicate with the Nimble group
-func NewClient(ipAddress, username, password, apiVersion string, waitOnJobs, isTenant bool) (*GroupMgmtClient, error) {
+func NewClient(ipAddress, username, password, apiVersion string, waitOnJobs, isTenant bool, tlsConfig *tls.Config) (*GroupMgmtClient, error) {
 	if apiVersion != "v1" {
 		return nil, fmt.Errorf("API version \"%s\" is not recognized", apiVersion)
 	}
 
 	// Get resty client
-	groupMgmtClient := newGroupMgmtClient(ipAddress, username, password, apiVersion, waitOnJobs, isTenant)
+	groupMgmtClient := newGroupMgmtClient(ipAddress, username, password, apiVersion, waitOnJobs, isTenant, tlsConfig)
 
 	// Get session token
 	sessionToken, err := groupMgmtClient.login(username, password)

--- a/pkg/client/group_mgmt_client_test.go
+++ b/pkg/client/group_mgmt_client_test.go
@@ -32,7 +32,7 @@ func TestNewClient(t *testing.T) {
 
 	// Create client
 	var err error
-	client, err = NewClient(os.Getenv("SDK_TARGET_HOST"), os.Getenv("SDK_TARGET_USER"), os.Getenv("SDK_TARGET_PASSWORD"), "v1", true, false)
+	client, err = NewClient(os.Getenv("SDK_TARGET_HOST"), os.Getenv("SDK_TARGET_USER"), os.Getenv("SDK_TARGET_PASSWORD"), "v1", true, false, nil)
 	if err != nil {
 		t.Errorf("NewClient(): Unable to create client, err: %v", err.Error())
 		return
@@ -99,7 +99,7 @@ func TestListGetOrPost(t *testing.T) {
 
 	// Create GMD client
 	var err error
-	client, err := NewClient(os.Getenv("SDK_TARGET_HOST"), os.Getenv("SDK_TARGET_USER"), os.Getenv("SDK_TARGET_PASSWORD"), "v1", true, false)
+	client, err := NewClient(os.Getenv("SDK_TARGET_HOST"), os.Getenv("SDK_TARGET_USER"), os.Getenv("SDK_TARGET_PASSWORD"), "v1", true, false, nil)
 	if err != nil {
 		t.Errorf("NewGmdClient(): Unable to create GMD client, err: %v", err.Error())
 		return

--- a/pkg/service/group_service_factory.go
+++ b/pkg/service/group_service_factory.go
@@ -3,6 +3,8 @@
 package service
 
 import (
+	"crypto/tls"
+
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/client"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/client/v1/nimbleos"
 	"github.com/hpe-storage/nimble-golang-sdk/pkg/param"
@@ -75,6 +77,7 @@ type GroupServiceOptions struct {
 	Password   string
 	IsTenant   bool
 	ApiVersion string
+	TLSConfig  *tls.Config
 }
 
 type ServiceOption func(*GroupServiceOptions)
@@ -123,10 +126,16 @@ func WithoutWaitForAsyncJobs() func(*GroupServiceOptions) {
 	}
 }
 
+func WithTLSConfig(tlsConfig *tls.Config) func(*GroupServiceOptions) {
+	return func(groupService *GroupServiceOptions) {
+		groupService.TLSConfig = tlsConfig
+	}
+}
+
 // NewNsGroupService - initializes NsGroupService
 // This function is deprecated. Call NewNimbleGroupService() to initialize a group service
 func NewNsGroupService(ip, username, password, apiVersion string, synchronous bool) (gs *NsGroupService, err error) {
-	client, err := client.NewClient(ip, username, password, apiVersion, synchronous, false)
+	client, err := client.NewClient(ip, username, password, apiVersion, synchronous, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +153,7 @@ func NewNimbleGroupService(serviceOpts ...ServiceOption) (gs *NsGroupService, er
 		opt(gso)
 	}
 
-	groupMgmtClient, err := client.NewClient(gso.Host, gso.Username, gso.Password, gso.ApiVersion, gso.WaitOnJob, gso.IsTenant)
+	groupMgmtClient, err := client.NewClient(gso.Host, gso.Username, gso.Password, gso.ApiVersion, gso.WaitOnJob, gso.IsTenant, gso.TLSConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## This PR proposes two things:
1) Adding a `service.ServiceOption` to provide a `tls.Config` to `NewNimbleGroupService()` which is in turn used by `resty.Client`
    
    The current behavior hard codes the tls connection to skip certificate verification, which is something that is not allowed in our security environment.
```
	restyClient.SetTLSClientConfig(&tls.Config{
		InsecureSkipVerify: true,
	})
```

2)  When using a **Tenant User**, certificates are **fully validated**.

Signed-off-by: Joseph Watson <jwatson@genisyscu.org>